### PR TITLE
import core package when launching console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val root = crossProject
       |import doodle.explore.syntax._
       |import doodle.explore.java2d._
       |import doodle.explore.java2d.examples._
+      |import doodle.core._
     """.trim.stripMargin,
     cleanupCommands in console := """
       |doodle.java2d.effect.Java2dRenderer.stop()


### PR DESCRIPTION
We notice that the core package needs to be imported in order to run the example in the README file. 

(@renatocaval on behalf of @lucascaval)