### PR TITLE
Add PDF writer based on https://github.com/eseifert/vectorgraphics2d

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,8 @@ lazy val interactJs  = interact.js.dependsOn(coreJs)
 lazy val java2d = project
   .in(file("java2d"))
   .settings(commonSettings,
-            moduleName := "doodle-java2d")
+            moduleName := "doodle-java2d",
+            libraryDependencies += "de.erichseifert.vectorgraphics2d" % "VectorGraphics2D" % "0.13")
   .dependsOn(coreJvm, exploreJvm, interactJvm)
 
 

--- a/core/shared/src/main/scala/doodle/algebra/generic/reified/Reified.scala
+++ b/core/shared/src/main/scala/doodle/algebra/generic/reified/Reified.scala
@@ -28,7 +28,7 @@ sealed abstract class Reified extends Product with Serializable {
   def transform: Tx
 
   /** finalTransform gives an transform applied after any other reified transform.
-    * Usually this is a transfrom from logical to screen coordinates. */
+    * Usually this is a transform from logical to screen coordinates. */
   def render[A](gc: A, finalTransform: Tx)(
       implicit ctx: GraphicsContext[A]): Unit =
     this match {

--- a/image/jvm/src/main/scala/doodle/image/examples/Write.scala
+++ b/image/jvm/src/main/scala/doodle/image/examples/Write.scala
@@ -10,7 +10,7 @@ import doodle.effect.Writer._
 import doodle.java2d._
 import doodle.java2d.effect.Frame
 
-object Write {
+object Write extends App {
   val frame = Frame.fitToPicture().background(Color.black)
 
   def rainbowCircles(count: Int, color: Color): Image =
@@ -28,4 +28,5 @@ object Write {
   // Draw with `Background.image.draw(Background.frame)`
   val image = rainbowCircles(12, Color.red)
   image.write[Png]("rainbow-circles.png", frame)
+  image.write[Pdf]("rainbow-circles.pdf", frame)
 }

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2d.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2d.scala
@@ -39,7 +39,7 @@ object Java2d {
 
   /**
    * Create a transform from local logical coordinates to screen coordinates
-   * given the bounding box for a picture, the screen size, and descriptino of
+   * given the bounding box for a picture, the screen size, and description of
    * the relationship between screen and picture.
    */
   def transform(bb: BoundingBox,

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dWriter.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dWriter.scala
@@ -18,12 +18,19 @@ package doodle
 package java2d
 package effect
 
+import java.awt.Graphics2D
+
 import cats.effect.IO
 import doodle.core.Transform
 import doodle.effect._
 import doodle.java2d.algebra.Algebra
 import java.awt.image.BufferedImage
-import java.io.File
+import java.io.{File, FileOutputStream}
+
+import de.erichseifert.vectorgraphics2d.intermediate.CommandSequence
+import de.erichseifert.vectorgraphics2d.pdf.PDFProcessor
+import de.erichseifert.vectorgraphics2d.util.PageSize
+import doodle.algebra.generic.BoundingBox
 import javax.imageio.ImageIO
 
 trait Java2dWriter[Format]
@@ -46,23 +53,39 @@ object Java2dWriter {
   def renderBufferedImage[A](frame: Frame,
                              picture: Picture[A]): IO[(BufferedImage, A)] =
     for {
+      rendered <- renderGraphics2D(frame, picture, bb => IO {
+        val (w, h) = Java2d.size(bb, frame.size)
+
+        val image = new BufferedImage(w.toInt,
+          h.toInt,
+          BufferedImage.TYPE_INT_ARGB)
+
+        (Java2d.setup(image.createGraphics()), image)
+      })
+      (image, a) = rendered
+    } yield (image, a)
+
+  private[java2d] def renderGraphics2D[A, I](frame: Frame,
+                             picture: Picture[A],
+                             graphicsContext: BoundingBox => IO[(Graphics2D, I)]): IO[(I, A)] =
+    for {
       drawing <- IO { picture(Algebra()) }
       (bb, rdr) = drawing.runA(List.empty).value
-      bi <- IO {
-        val (w, h) = Java2d.size(bb, frame.size)
-        new BufferedImage(w.toInt,
-                          h.toInt,
-                          BufferedImage.TYPE_INT_ARGB)
-      }
-      gc = Java2d.setup(bi.createGraphics())
       (_, fa) = rdr.run(Transform.identity).value
       (r, a) = fa.run.value
-      tx = Java2d.transform(bb,
-                            bi.getWidth.toDouble,
-                            bi.getHeight.toDouble,
-                            frame.center)
+      tx = {
+        val (width, height) = Java2d.size(bb, frame.size)
+
+        Java2d.transform(bb,
+          width.toDouble,
+          height.toDouble,
+          frame.center)
+      }
+      contextWithImage <- graphicsContext(bb)
+      (gc, image) = contextWithImage
       _ = Java2d.render(gc, r, tx)
-    } yield (bi, a)
+    } yield (image, a)
+
 }
 object Java2dGifWriter extends Java2dWriter[Writer.Gif] {
   val format = "gif"
@@ -72,4 +95,33 @@ object Java2dPngWriter extends Java2dWriter[Writer.Png] {
 }
 object Java2dJpgWriter extends Java2dWriter[Writer.Jpg] {
   val format = "jpg"
+}
+
+object Java2dPdfWriter extends Java2dWriter[Writer.Pdf] {
+  val format = "pdf"
+
+  import de.erichseifert.vectorgraphics2d.VectorGraphics2D
+
+  private def renderVectorCommands[A](frame: Frame,
+                              picture: Picture[A]): IO[((CommandSequence, BoundingBox), A)] =
+    for {
+      rendered <- Java2dWriter.renderGraphics2D(frame, picture, bb => IO {
+        val vectorGraphics = new VectorGraphics2D()
+        (vectorGraphics, (vectorGraphics, bb))
+      })
+      ((image, bounds), a) = rendered
+    } yield ((image.getCommands, bounds), a)
+
+  override def write[A](file: File, frame: Frame, picture: Picture[A]): IO[A] =
+    for {
+      result <- renderVectorCommands(frame, picture)
+      ((commands, bounds), value) = result
+      _ <- IO {
+        val (width, height) = Java2d.size(bounds, frame.size)
+
+        val pdfProcessor = new PDFProcessor(true)
+        val doc = pdfProcessor.getDocument(commands, new PageSize(width, height))
+        doc.writeTo(new FileOutputStream(file))
+      }
+    } yield value
 }

--- a/java2d/src/main/scala/doodle/java2d/package.scala
+++ b/java2d/src/main/scala/doodle/java2d/package.scala
@@ -55,6 +55,7 @@ package object java2d extends effect.Java2dExplorerAtoms {
   implicit val java2dGifWriter = doodle.java2d.effect.Java2dGifWriter
   implicit val java2dPngWriter = doodle.java2d.effect.Java2dPngWriter
   implicit val java2dJpgWriter = doodle.java2d.effect.Java2dJpgWriter
+  implicit val java2dPdfWriter = doodle.java2d.effect.Java2dPdfWriter
 
   val Frame = doodle.java2d.effect.Frame
 


### PR DESCRIPTION
To do this a split up of the Java2d rendering was needed, to render a
Graphics2D context independent of a buffered image.

fixes https://github.com/creativescala/doodle/issues/46

+ fix some typos along the way