### PR TITLE
Allow to return a base64 encoded string for an image

### DIFF
--- a/core/shared/src/main/scala/doodle/effect/Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Writer.scala
@@ -25,6 +25,7 @@ import java.io.File
 trait Writer[Alg[x[_]] <: Algebra[x], F[_], Frame, Format] {
   def write[A](file: File, description: Frame, image: Picture[Alg, F, A]): IO[A]
   def write[A](file: File, image: Picture[Alg, F, A]): IO[A]
+  def base64[A](image: Picture[Alg, F, A]): IO[(A, String)]
 }
 object Writer {
   /* Standard format type for PDF writer */

--- a/image/jvm/src/main/scala/doodle/image/examples/Write.scala
+++ b/image/jvm/src/main/scala/doodle/image/examples/Write.scala
@@ -10,7 +10,7 @@ import doodle.effect.Writer._
 import doodle.java2d._
 import doodle.java2d.effect.Frame
 
-object Write {
+object Write extends App {
   val frame = Frame.fitToPicture().background(Color.black)
 
   def rainbowCircles(count: Int, color: Color): Image =
@@ -28,4 +28,5 @@ object Write {
   // Draw with `Background.image.draw(Background.frame)`
   val image = rainbowCircles(12, Color.red)
   image.write[Png]("rainbow-circles.png", frame)
+  println(image.write[Png].base64)
 }

--- a/image/shared/src/main/scala/doodle/image/syntax/ImageSyntax.scala
+++ b/image/shared/src/main/scala/doodle/image/syntax/ImageSyntax.scala
@@ -65,5 +65,12 @@ trait ImageSyntax {
                frame,
                Picture((algebra: Alg[F]) => image.compile(algebra)))
         .unsafeRunSync()
+
+    def base64[Alg[x[_]] <: Basic[x], F[_], Frame](
+      implicit w: Writer[Alg, F, Frame, Format]): String = {
+      val picture = Picture((algebra: Alg[F]) => image.compile(algebra))
+      val (_, base64String) = w.base64(picture).unsafeRunSync()
+      base64String
+    }
   }
 }

--- a/svg/jvm/src/main/scala/doodle/svg/effect/SvgWriter.scala
+++ b/svg/jvm/src/main/scala/doodle/svg/effect/SvgWriter.scala
@@ -7,6 +7,8 @@ import doodle.effect._
 import doodle.algebra.Picture
 import java.io.File
 import java.nio.file.Files
+import java.util.Base64
+
 import scalatags.Text
 
 object SvgWriter extends Writer[Algebra, Drawing, Frame, Writer.Svg] {
@@ -29,4 +31,9 @@ object SvgWriter extends Writer[Algebra, Drawing, Frame, Writer.Svg] {
 
   def write[A](file: File, picture: Picture[Algebra, Drawing, A]): IO[A] =
     write(file, Frame("").fitToPicture(), picture)
+
+  override def base64[A](image: Picture[Algebra, Drawing, A]): IO[(A, String)] = for {
+    rendered <- svg.render[Algebra, A](Frame("").fitToPicture(), algebra, image)
+    (nodes, value) = rendered
+  } yield (value, Base64.getEncoder.encodeToString(nodes.getBytes()))
 }


### PR DESCRIPTION
This extends the writer to return an image as base64 encoded
string (in the given format) instead of writing it to a file.

Currently it is only supported without the frame description.

fixes https://github.com/creativescala/doodle/issues/77