### PR TITLE
Add the XML namespace attribute when generating SVG tags

### DIFF
--- a/svg/shared/src/main/scala/doodle/svg/algebra/Svg.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/Svg.scala
@@ -61,6 +61,7 @@ trait SvgModule { self: Base =>
           val w = bb.width + (2 * border)
           val h = bb.height + (2 * border)
           svg.svg(
+            svgAttrs.xmlns := s"http://www.w3.org/2000/svg"
             svgAttrs.width := w,
             svgAttrs.height := h,
             svgAttrs.viewBox := s"${bb.left - border} ${bb.bottom - border} ${w} ${h}",


### PR DESCRIPTION
Browsers and ebook readers will not render SVG tags properly if there is no XML namespace specified. This should also fix https://github.com/creativescala/creative-scala/issues/77 and https://github.com/creativescala/creative-scala/issues/72 once the images are re-rendered.