### PR TITLE
Maybe draw equilateral triangles, rather than isosceles ones, in Sierpinski.scala

### DIFF
--- a/image/shared/src/main/scala/doodle/image/examples/Sierpinski.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Sierpinski.scala
@@ -8,6 +8,14 @@ import doodle.image.Image
 object Sierpinski {
   def triangle(size: Double): Image = {
     println(s"Creating a triangle")
+    // This is just a suggestion.
+    // https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle says that the triangles are 
+    // equilateral: "The Sierpiński triangle ...is a fractal attractive fixed set with the 
+    // overall shape of an equilateral triangle, subdivided recursively into smaller 
+    // equilateral triangles".
+    // By passing in width=size and height=size, we are creating an isosceles triangle. 
+    // If desired, we can instead draw an equilateral triangle by passing in height=√3÷2×size.
+    // See https://www.slideshare.net/pjschwarz/sierpinski-triangle-polyglot-fp-for-fun-and-profit-haskell-and-scala-with-minor-corrections#49
     Image.triangle(size, size).strokeColor(Color.magenta)
   }
 


### PR DESCRIPTION
Hello. I love this Sierpinski function: it makes for a great example of recursion. I hit upon this Doodle version as I worked on https://www.slideshare.net/pjschwarz/sierpinski-triangle-polyglot-fp-for-fun-and-profit-haskell-and-scala-with-minor-corrections.

I have a small suggestion to make: see the comment I left in the code.

Of course if you are at all interested in making any change, you will do it yourself, but FWIW, here could be one way to do it: https://www.slideshare.net/pjschwarz/sierpinski-triangle-polyglot-fp-for-fun-and-profit-haskell-and-scala-with-minor-corrections#49:

```Scala
  object EquilateralTriangle:
    // From https://en.wikipedia.org/wiki/Square_root_of_3:
    // The square root of 3 ...is also known as Theodorus' constant,
    // after Theodorus of Cyrene, who proved its irrationality.
    private val constantOfTheodorus: Double = Math.sqrt(3)

    // From https://en.wikipedia.org/wiki/Equilateral_triangle:
    // The altitude (height) h from any side a is √3÷2×a
    private val widthToHeightMultiplier = constantOfTheodorus / 2

    def heightFromWidth(width: Double): Double =
      widthToHeightMultiplier * width
```

```Scala
Image.triangle(width = size, height = EquilateralTriangle.heightFromWidth(size))
```