### PR TITLE
WIP: Use fs2 and cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,7 @@ lazy val java2d = project
     libraryDependencies ++= Seq(
       "de.erichseifert.vectorgraphics2d" % "VectorGraphics2D" % "0.13"
     ),
+    libraryDependencies += Dependencies.fs2.value,
     libraryDependencies ++=
       (if (scalaBinaryVersion == "2.13")
          List(

--- a/docs/src/main/scala/Chessboard.scala
+++ b/docs/src/main/scala/Chessboard.scala
@@ -1,6 +1,7 @@
 package docs
 
 // The "Image" DSL is the easiest way to create images
+import cats.effect.unsafe.implicits.global
 import doodle.core._
 import doodle.image._
 

--- a/docs/src/main/scala/algebra/BasicWithText.scala
+++ b/docs/src/main/scala/algebra/BasicWithText.scala
@@ -1,6 +1,7 @@
 package docs
 package algebra
 
+import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import doodle.algebra.Picture
 import doodle.algebra.Text
@@ -10,6 +11,7 @@ import doodle.language.Basic
 import doodle.syntax._
 
 object BasicWithText {
+
   def basicWithText[Alg[x[_]] <: Basic[x] with Text[x], F[_]]
       : Picture[Alg, F, Unit] = {
     val redCircle = circle[Alg, F](100).strokeColor(Color.red)

--- a/docs/src/main/scala/algebra/OldGod.scala
+++ b/docs/src/main/scala/algebra/OldGod.scala
@@ -1,6 +1,7 @@
 package docs
 package algebra
 
+import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import doodle.core._
 import doodle.java2d._

--- a/docs/src/main/scala/package.scala
+++ b/docs/src/main/scala/package.scala
@@ -7,7 +7,7 @@ package object docs {
 
   implicit class ImageSaveSyntax(image: Image) {
     import doodle.image.syntax._
-    def save(filename: String): Unit = {
+    def save(filename: String)(implicit r: IORuntime): Unit = {
       val dir = new File("docs/src/main/mdoc/")
       val file = new File(dir, filename)
       image.write[Png](file)

--- a/golden/src/test/scala/doodle/golden/Golden.scala
+++ b/golden/src/test/scala/doodle/golden/Golden.scala
@@ -1,6 +1,7 @@
 package doodle
 package golden
 
+import cats.effect.unsafe.implicits.global
 import doodle.effect.Writer.Png
 import doodle.java2d._
 import doodle.syntax._

--- a/golden/src/test/scala/doodle/golden/GoldenImage.scala
+++ b/golden/src/test/scala/doodle/golden/GoldenImage.scala
@@ -1,6 +1,7 @@
 package doodle
 package golden
 
+import cats.effect.unsafe.implicits.global
 import doodle.effect.Writer._
 import doodle.java2d._
 import munit._

--- a/golden/src/test/scala/doodle/golden/GoldenPicture.scala
+++ b/golden/src/test/scala/doodle/golden/GoldenPicture.scala
@@ -1,6 +1,7 @@
 package doodle
 package golden
 
+import cats.effect.unsafe.implicits.global
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.effect.Writer

--- a/image/jvm/src/main/scala/doodle/image/examples/Write.scala
+++ b/image/jvm/src/main/scala/doodle/image/examples/Write.scala
@@ -3,6 +3,7 @@ package image
 package examples
 
 // Example that demonstrates writing to a file
+import cats.effect.unsafe.implicits.global
 import doodle.core._
 import doodle.effect.Writer._
 import doodle.image.syntax._

--- a/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
+++ b/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
@@ -18,6 +18,7 @@ package doodle
 package image
 package syntax
 
+import cats.effect.unsafe.IORuntime
 import doodle.algebra.Picture
 import doodle.core.{Base64 => B64}
 import doodle.effect.Base64
@@ -35,7 +36,8 @@ trait JvmImageSyntax extends ImageSyntax {
     */
   final class Base64Ops[Format](image: Image) {
     def apply[Alg[x[_]] <: Basic[x], F[_], Frame](implicit
-        w: Base64[Alg, F, Frame, Format]
+        w: Base64[Alg, F, Frame, Format],
+        runtime: IORuntime
     ): B64[Format] = {
       val picture = Picture((algebra: Alg[F]) => image.compile(algebra))
       val (_, base64) = w.base64(picture).unsafeRunSync()

--- a/interact/shared/src/main/scala/doodle/interact/algebra/MouseClick.scala
+++ b/interact/shared/src/main/scala/doodle/interact/algebra/MouseClick.scala
@@ -2,8 +2,10 @@ package doodle
 package interact
 package algebra
 
+import cats.effect.IO
 import doodle.core.Point
-import fs2.{Pure, Stream}
+import fs2.Pure
+import fs2.Stream
 
 /** Algebra for generating a stream of events corresponding to mouse clicks.
   * Whenever the mouse is clicked a new event is generated with the location of
@@ -22,5 +24,5 @@ trait MouseClick[Canvas] {
     * On systems, such as the browser, that will emulate touch events as mouse
     * events this will also return such touch events.
     */
-  def mouseClick(canvas: Canvas): Stream[Pure, Point]
+  def mouseClick(canvas: Canvas): Stream[IO, Point]
 }

--- a/interact/shared/src/main/scala/doodle/interact/algebra/MouseMove.scala
+++ b/interact/shared/src/main/scala/doodle/interact/algebra/MouseMove.scala
@@ -2,8 +2,10 @@ package doodle
 package interact
 package algebra
 
+import cats.effect.IO
 import doodle.core.Point
-import fs2.{Pure, Stream}
+import fs2.Pure
+import fs2.Stream
 
 /** Algebra for generating a stream of events giving the current mouse location.
   * Whenever the mouse moves a new event is generated. The algebra applies to a
@@ -17,5 +19,5 @@ trait MouseMove[Canvas] {
     * canvas. The coordinate system used is the global coordinate system used by
     * the Canvas, which usually means the origin is centered on the canvas.
     */
-  def mouseMove(canvas: Canvas): Stream[Pure, Point]
+  def mouseMove(canvas: Canvas): Stream[IO, Point]
 }

--- a/interact/shared/src/main/scala/doodle/interact/algebra/MouseOver.scala
+++ b/interact/shared/src/main/scala/doodle/interact/algebra/MouseOver.scala
@@ -3,7 +3,8 @@ package interact
 package algebra
 
 import doodle.algebra.Algebra
-import fs2.{Pure, Stream}
+import fs2.Pure
+import fs2.Stream
 
 /** Algebra for elements that can respond to Mouseover events */
 trait MouseOver[F[_]] extends Algebra[F] {

--- a/interact/shared/src/main/scala/doodle/interact/algebra/Redraw.scala
+++ b/interact/shared/src/main/scala/doodle/interact/algebra/Redraw.scala
@@ -2,7 +2,9 @@ package doodle
 package interact
 package algebra
 
-import fs2.{Pure, Stream}
+import cats.effect.IO
+import fs2.Pure
+import fs2.Stream
 
 /** Algebra for generating a stream of events indicating when the canvas is
   * ready to redraw. The algebra applies to a Renderer's Canvas data type
@@ -14,5 +16,5 @@ trait Redraw[Canvas] {
     * redraw. The value is the approximate time in millisecond since a frame was
     * last rendered.
     */
-  def redraw(canvas: Canvas): Stream[Pure, Int]
+  def redraw(canvas: Canvas): Stream[IO, Int]
 }

--- a/interact/shared/src/main/scala/doodle/interact/animation/Transducer.scala
+++ b/interact/shared/src/main/scala/doodle/interact/animation/Transducer.scala
@@ -19,6 +19,7 @@ package interact
 package animation
 
 import cats._
+import cats.effect.unsafe.IORuntime
 import cats.implicits._
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
@@ -26,7 +27,8 @@ import doodle.effect.Renderer
 import doodle.interact.algebra.Redraw
 import doodle.interact.effect.AnimationRenderer
 import doodle.interact.syntax.animationRenderer._
-import fs2.{Pure, Stream}
+import fs2.Pure
+import fs2.Stream
 
 import scala.annotation.tailrec
 
@@ -362,7 +364,8 @@ trait Transducer[Output] { self =>
       a: AnimationRenderer[Canvas],
       e: Renderer[Alg, F, Frame, Canvas],
       r: Redraw[Canvas],
-      ev: Output <:< Picture[Alg, F, Unit]
+      ev: Output <:< Picture[Alg, F, Unit],
+      runtime: IORuntime
   ): Unit =
     this.toStream.map(ev(_)).animateFrames(frame)
 }

--- a/interact/shared/src/main/scala/doodle/interact/easing/Easing.scala
+++ b/interact/shared/src/main/scala/doodle/interact/easing/Easing.scala
@@ -2,7 +2,8 @@ package doodle
 package interact
 package easing
 
-import monix.reactive.Observable
+import fs2.Pure
+import fs2.Stream
 
 /** An easing function is a function from [0,1] to the real numbers (but usually
   * numbers in [0,1]) that is used to construct animation that move in a
@@ -35,11 +36,11 @@ trait Easing extends Function1[Double, Double] {
       1.0 - this(1.0 - t)
     }
 
-  /** Convert to an Observable that produces a total of steps values, starting
-    * at 0.0 and finishing at 1.0
+  /** Convert to a Stream that produces a total of steps values, starting at 0.0
+    * and finishing at 1.0
     */
-  def toObservable(steps: Int): Observable[Double] =
-    Observable
+  def toStream(steps: Int): Stream[Pure, Double] =
+    Stream
       .range(0L, steps.toLong)
       .map(step =>
         if (step == 0) 0.0

--- a/interact/shared/src/main/scala/doodle/interact/effect/AnimationRenderer.scala
+++ b/interact/shared/src/main/scala/doodle/interact/effect/AnimationRenderer.scala
@@ -23,20 +23,18 @@ import cats.effect.IO
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.effect.Renderer
-import monix.execution.Scheduler
-import monix.reactive.Observable
+import fs2.Stream
 
 /** The `AnimationRenderer` typeclass describes a data type that can render an
   * animation to a Canvas.
   */
 trait AnimationRenderer[Canvas] {
 
-  /** Animate frames that are produced by an `Observable`. */
+  /** Animate frames that are produced by a `Stream`. */
   def animate[Alg[x[_]] <: Algebra[x], F[_], A, Frame](
       canvas: Canvas
-  )(frames: Observable[Picture[Alg, F, A]])(implicit
+  )(frames: Stream[IO, Picture[Alg, F, A]])(implicit
       e: Renderer[Alg, F, Frame, Canvas],
-      s: Scheduler,
       m: Monoid[A]
   ): IO[A]
 }

--- a/interact/shared/src/main/scala/doodle/interact/effect/AnimationWriter.scala
+++ b/interact/shared/src/main/scala/doodle/interact/effect/AnimationWriter.scala
@@ -22,8 +22,7 @@ import cats.Monoid
 import cats.effect.IO
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
-import monix.execution.Scheduler
-import monix.reactive.Observable
+import fs2.Stream
 
 import java.io.File
 
@@ -35,6 +34,6 @@ trait AnimationWriter[Alg[x[_]] <: Algebra[x], F[_], Frame, Format] {
   def write[A](
       file: File,
       description: Frame,
-      frames: Observable[Picture[Alg, F, A]]
-  )(implicit s: Scheduler, m: Monoid[A]): IO[A]
+      frames: Stream[IO, Picture[Alg, F, A]]
+  )(implicit m: Monoid[A]): IO[A]
 }

--- a/interact/shared/src/main/scala/doodle/interact/examples/Orbit.scala
+++ b/interact/shared/src/main/scala/doodle/interact/examples/Orbit.scala
@@ -6,7 +6,8 @@ import doodle.algebra.Picture
 import doodle.core._
 import doodle.language.Basic
 import doodle.syntax._
-import monix.reactive.Observable
+import fs2.Pure
+import fs2.Stream
 
 object Orbit {
 
@@ -15,8 +16,8 @@ object Orbit {
       .fillColor(Color.brown.spin(angle))
       .at(Point(200, angle))
 
-  def frames[F[_]]: Observable[Picture[Basic, F, Unit]] =
-    Observable
+  def frames[F[_]]: Stream[Pure, Picture[Basic, F, Unit]] =
+    Stream
       .range(0, 360, 1)
       .map(a => a.toDouble.degrees)
       .map(planet _)

--- a/interact/shared/src/main/scala/doodle/interact/syntax/AnimationWriterSyntax.scala
+++ b/interact/shared/src/main/scala/doodle/interact/syntax/AnimationWriterSyntax.scala
@@ -4,12 +4,11 @@ package syntax
 
 import cats.Monoid
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.interact.effect.AnimationWriter
-import monix.execution.Scheduler
-import monix.reactive.Observable
-import monix.reactive.ObservableLike
+import fs2.Stream
 
 import java.io.File
 
@@ -23,8 +22,8 @@ trait AnimationWriterSyntax {
       case Right(_) => ()
     }
 
-  implicit class AnimationWriterObservableOps[Alg[x[_]] <: Algebra[x], F[_], A](
-      frames: Observable[Picture[Alg, F, A]]
+  implicit class AnimationWriterStreamOps[Alg[x[_]] <: Algebra[x], F[_], A](
+      frames: Stream[IO, Picture[Alg, F, A]]
   ) {
 
     def writeToIO[Format] =
@@ -34,17 +33,15 @@ trait AnimationWriterSyntax {
       new AnimationWriterOpsHelper[Format](frames)
 
     class AnimationWriterIOOpsHelper[Format](
-        frames: Observable[Picture[Alg, F, A]]
+        frames: Stream[IO, Picture[Alg, F, A]]
     ) {
       def apply[Frame](file: String, frame: Frame)(implicit
-          s: Scheduler,
           m: Monoid[A],
           w: AnimationWriter[Alg, F, Frame, Format]
       ): IO[A] =
         apply(new File(file), frame)
 
       def apply[Frame](file: File, frame: Frame)(implicit
-          s: Scheduler,
           m: Monoid[A],
           w: AnimationWriter[Alg, F, Frame, Format]
       ): IO[A] =
@@ -52,32 +49,21 @@ trait AnimationWriterSyntax {
     }
 
     class AnimationWriterOpsHelper[Format](
-        frames: Observable[Picture[Alg, F, A]]
+        frames: Stream[IO, Picture[Alg, F, A]]
     ) {
       def apply[Frame](file: String, frame: Frame)(implicit
-          s: Scheduler,
           m: Monoid[A],
-          w: AnimationWriter[Alg, F, Frame, Format]
+          w: AnimationWriter[Alg, F, Frame, Format],
+          runtime: IORuntime
       ): Unit =
         apply(new File(file), frame)
 
       def apply[Frame](file: File, frame: Frame)(implicit
-          s: Scheduler,
           m: Monoid[A],
-          w: AnimationWriter[Alg, F, Frame, Format]
+          w: AnimationWriter[Alg, F, Frame, Format],
+          runtime: IORuntime
       ): Unit =
         w.write(file, frame, frames).unsafeRunAsync(nullCallback)
     }
-  }
-
-  implicit class AnimationWriterObservableLikeOps[Alg[x[_]] <: Algebra[x], F[
-      _
-  ], G[_], A](frames: G[Picture[Alg, F, A]]) {
-
-    def writeFramesToIO[Format](implicit o: ObservableLike[G]) =
-      o(frames).writeToIO[Format]
-
-    def writeFrames[Format](implicit o: ObservableLike[G]) =
-      o(frames).write[Format]
   }
 }

--- a/interact/shared/src/main/scala/doodle/interact/syntax/MouseClickSyntax.scala
+++ b/interact/shared/src/main/scala/doodle/interact/syntax/MouseClickSyntax.scala
@@ -2,13 +2,14 @@ package doodle
 package interact
 package syntax
 
+import cats.effect.IO
 import doodle.core.Point
 import doodle.interact.algebra.MouseClick
-import monix.reactive.Observable
+import fs2.Stream
 
 trait MouseClickSyntax {
   implicit class MouseClickOps[Canvas](canvas: Canvas) {
-    def mouseClick(implicit m: MouseClick[Canvas]): Observable[Point] =
+    def mouseClick(implicit m: MouseClick[Canvas]): Stream[IO, Point] =
       m.mouseClick(canvas)
   }
 }

--- a/interact/shared/src/main/scala/doodle/interact/syntax/MouseMoveSyntax.scala
+++ b/interact/shared/src/main/scala/doodle/interact/syntax/MouseMoveSyntax.scala
@@ -2,13 +2,14 @@ package doodle
 package interact
 package syntax
 
+import cats.effect.IO
 import doodle.core.Point
 import doodle.interact.algebra.MouseMove
-import monix.reactive.Observable
+import fs2.Stream
 
 trait MouseMoveSyntax {
   implicit class MouseMoveOps[Canvas](canvas: Canvas) {
-    def mouseMove(implicit m: MouseMove[Canvas]): Observable[Point] =
+    def mouseMove(implicit m: MouseMove[Canvas]): Stream[IO, Point] =
       m.mouseMove(canvas)
   }
 }

--- a/interact/shared/src/main/scala/doodle/interact/syntax/MouseOverSyntax.scala
+++ b/interact/shared/src/main/scala/doodle/interact/syntax/MouseOverSyntax.scala
@@ -2,30 +2,20 @@ package doodle
 package interact
 package syntax
 
+import cats.effect.IO
 import doodle.algebra.Picture
 import doodle.interact.algebra.MouseOver
-import monix.reactive.Observable
-import monix.reactive.subjects.PublishSubject
+import fs2.Stream
 
 trait MouseOverSyntax {
   implicit class MouseOverOps[F[_], A](picture: F[A]) {
-    def mouseOver(implicit m: MouseOver[F]): (F[A], Observable[Unit]) =
+    def mouseOver(implicit m: MouseOver[F]): (F[A], Stream[IO, Unit]) =
       m.mouseOver(picture)
   }
 
   implicit class MouseOverPictureOps[Alg[x[_]] <: MouseOver[x], F[_], A](
       picture: Picture[Alg, F, A]
   ) {
-    def mouseOver: (Picture[Alg, F, A], Observable[Unit]) = {
-      val obs = PublishSubject[Unit]()
-      val p = Picture { implicit algebra: Alg[F] =>
-        val f1 = picture(algebra)
-        val (f2, o) = f1.mouseOver
-        o.map(obs.onNext _)
-        f2
-      }
-
-      (p, obs)
-    }
+    def mouseOver: IO[(Picture[Alg, F, A], Stream[IO, Unit])] = ???
   }
 }

--- a/interact/shared/src/main/scala/doodle/interact/syntax/RedrawSyntax.scala
+++ b/interact/shared/src/main/scala/doodle/interact/syntax/RedrawSyntax.scala
@@ -2,12 +2,13 @@ package doodle
 package interact
 package syntax
 
+import cats.effect.IO
 import doodle.interact.algebra.Redraw
-import monix.reactive.Observable
+import fs2.Stream
 
 trait RedrawSyntax {
   implicit class RedrawOps[Canvas](canvas: Canvas) {
-    def redraw(implicit r: Redraw[Canvas]): Observable[Int] =
+    def redraw(implicit r: Redraw[Canvas]): Stream[IO, Int] =
       r.redraw(canvas)
   }
 }

--- a/java2d/src/main/scala/doodle/java2d/algebra/CanvasAlgebra.scala
+++ b/java2d/src/main/scala/doodle/java2d/algebra/CanvasAlgebra.scala
@@ -18,26 +18,27 @@ package doodle
 package java2d
 package algebra
 
+import cats.effect.IO
 import doodle.core.Point
 import doodle.interact.algebra.MouseClick
 import doodle.interact.algebra.MouseMove
 import doodle.interact.algebra.Redraw
 import doodle.java2d.effect.Canvas
-import monix.reactive.Observable
+import fs2.Stream
 
 case object CanvasAlgebra
     extends MouseClick[Canvas]
     with MouseMove[Canvas]
     with Redraw[Canvas] {
-  def mouseClick(canvas: Canvas): Observable[Point] = {
+  def mouseClick(canvas: Canvas): Stream[IO, Point] = {
     canvas.mouseClick
   }
 
-  def mouseMove(canvas: Canvas): Observable[Point] = {
+  def mouseMove(canvas: Canvas): Stream[IO, Point] = {
     canvas.mouseMove
   }
 
-  def redraw(canvas: Canvas): Observable[Int] = {
+  def redraw(canvas: Canvas): Stream[IO, Int] = {
     canvas.redraw
   }
 }

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2DPanel.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2DPanel.scala
@@ -19,6 +19,7 @@ package java2d
 package effect
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import doodle.core.BoundingBox
 import doodle.core.Normalized
 import doodle.core.Transform
@@ -35,7 +36,8 @@ import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import scala.collection.mutable.ArrayBuffer
 
-final class Java2DPanel(frame: Frame) extends JPanel {
+final class Java2DPanel(frame: Frame)(implicit runtime: IORuntime)
+    extends JPanel {
   import Java2DPanel.RenderRequest
 
   /** The channel communicates between the Swing thread and outside threads

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dAnimationRenderer.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dAnimationRenderer.scala
@@ -22,26 +22,17 @@ import cats.Monoid
 import cats.effect.IO
 import doodle.effect.Renderer
 import doodle.interact.effect.AnimationRenderer
-import monix.eval.Task
-import monix.eval.TaskLift
-import monix.execution.Scheduler
-import monix.reactive.Consumer
-import monix.reactive.Observable
+import fs2.Stream
 
 object Java2dAnimationRenderer extends AnimationRenderer[Canvas] {
   def animate[Alg[x[_]] <: doodle.algebra.Algebra[x], F[_], A, Frm](
       canvas: Canvas
-  )(frames: Observable[doodle.algebra.Picture[Alg, F, A]])(implicit
+  )(frames: Stream[IO, doodle.algebra.Picture[Alg, F, A]])(implicit
       e: Renderer[Alg, F, Frm, Canvas],
-      s: Scheduler,
       m: Monoid[A]
   ): IO[A] =
     frames
-      .mapEval { img =>
-        Task.from(e.render(canvas)(img))
-      }
-      .consumeWith(Consumer.foldLeft(m.empty) { (accum, a) =>
-        m.combine(accum, a)
-      })
-      .to[IO](TaskLift.toIO(Task.catsEffect(s)))
+      .evalMap(e.render(canvas))
+      .compile
+      .foldMonoid
 }

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dRenderer.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dRenderer.scala
@@ -24,15 +24,18 @@ import doodle.effect.DefaultRenderer
 import javax.swing.JFrame
 
 object Java2dRenderer extends DefaultRenderer[Algebra, Drawing, Frame, Canvas] {
+
+  import cats.effect.unsafe.implicits.global
+
   private var jFrames: List[JFrame] = List.empty
 
   val default: Frame = Frame.fitToPicture()
 
   def canvas(description: Frame): IO[Canvas] =
-    IO {
-      val jFrame = new Canvas(description)
-      jFrames.synchronized { jFrames = jFrame :: jFrames }
-      jFrame
+    Canvas(description).flatMap { jFrame =>
+      IO {
+        jFrames.synchronized { jFrames = jFrame :: jFrames }
+      }.as(jFrame)
     }
 
   def render[A](canvas: Canvas)(picture: Picture[A]): IO[A] =

--- a/java2d/src/main/scala/doodle/java2d/examples/BouncyCircles.scala
+++ b/java2d/src/main/scala/doodle/java2d/examples/BouncyCircles.scala
@@ -26,29 +26,27 @@ object BouncyCircles {
   import doodle.java2d.effect._
   import doodle.interact.easing._
   import doodle.interact.syntax._
-  import monix.reactive.Observable
-  import monix.execution.Scheduler.Implicits.global
+  import fs2.Stream
+  import cats.effect.IO
+  import cats.effect.unsafe.implicits.global
 
   val frame = Frame.size(600, 600).background(Color.darkMagenta)
   val steps = 60 * 10
 
-  def bounce(easing: Easing): Observable[Double] =
-    easing.toObservable(steps) ++
-      easing.toObservable(steps) ++
-      easing.toObservable(steps) ++
-      easing.toObservable(steps)
+  def bounce(easing: Easing): Stream[IO, Double] =
+    easing.toStream(steps) ++
+      easing.toStream(steps) ++
+      easing.toStream(steps) ++
+      easing.toStream(steps)
 
-  val animation: Observable[Picture[Unit]] =
-    Observable
-      .zip6(
-        bounce(Easing.linear),
-        bounce(Easing.quadratic),
-        bounce(Easing.cubic),
-        bounce(Easing.sin),
-        bounce(Easing.circle),
-        bounce(Easing.back)
-      )
-      .map { case (r1, r2, r3, r4, r5, r6) =>
+  val animation: Stream[IO, Picture[Unit]] =
+    bounce(Easing.linear)
+      .zip(bounce(Easing.quadratic))
+      .zip(bounce(Easing.cubic))
+      .zip(bounce(Easing.sin))
+      .zip(bounce(Easing.circle))
+      .zip(bounce(Easing.back))
+      .map { case (((((r1, r2), r3), r4), r5), r6) =>
         circle[Algebra, Drawing](r1 * 85 + 10)
           .strokeColor(Color.magenta.spin(180.degrees))
           .at(r1 * 400 - 200, 250)

--- a/java2d/src/main/scala/doodle/java2d/examples/Dash.scala
+++ b/java2d/src/main/scala/doodle/java2d/examples/Dash.scala
@@ -25,9 +25,10 @@ object Dash {
   import doodle.syntax._
   import doodle.java2d.effect._
   import doodle.interact.syntax._
-  import monix.reactive.Observable
+  import fs2.Stream
+  import cats.effect.IO
   import scala.concurrent.duration._
-  import monix.execution.Scheduler.Implicits.global
+  import cats.effect.unsafe.implicits.global
 
   val frame = Frame.size(600, 600).background(Color.midnightBlue)
   val maxSize = 300
@@ -46,10 +47,9 @@ object Dash {
       .strokeColor(Color.limeGreen)
       .strokeWidth(5.0)
 
-  val animation: Observable[Picture[Unit]] =
-    Observable
-      .repeat(1)
-      .sample(200.millis)
+  val animation: Stream[IO, Picture[Unit]] =
+    Stream(1).repeat
+      .debounce[IO](200.millis)
       .scan((1, 0)) { (state, _) =>
         val (inc, size) = state
         if (size >= maxSize) (-increment, maxSize - increment)

--- a/java2d/src/main/scala/doodle/java2d/examples/PulsingCircle.scala
+++ b/java2d/src/main/scala/doodle/java2d/examples/PulsingCircle.scala
@@ -25,8 +25,9 @@ object PulsingCircle {
   import doodle.syntax._
   import doodle.java2d.effect._
   import doodle.interact.syntax._
-  import monix.reactive.Observable
-  import monix.execution.Scheduler.Implicits.global
+  import fs2.Stream
+  import cats.effect.IO
+  import cats.effect.unsafe.implicits.global
 
   val frame = Frame.size(600, 600).background(Color.midnightBlue)
 
@@ -79,9 +80,8 @@ object PulsingCircle {
           )
     }
 
-  val animation: Observable[Picture[Unit]] =
-    Observable
-      .repeat(1)
+  val animation: Stream[IO, Picture[Unit]] =
+    Stream(1).repeat
       .scan((1, 0)) { (state, _) =>
         val (inc, count) = state
         if (count >= maxNumberOfDisks) (-1, maxNumberOfDisks - 1)

--- a/java2d/src/test/scala/doodle/java2d/Base64Spec.scala
+++ b/java2d/src/test/scala/doodle/java2d/Base64Spec.scala
@@ -1,6 +1,7 @@
 package doodle
 package java2d
 
+import cats.effect.unsafe.implicits.global
 import doodle.core.Base64
 import doodle.effect.Writer._
 import doodle.syntax._

--- a/java2d/src/test/scala/doodle/java2d/ToPictureSpec.scala
+++ b/java2d/src/test/scala/doodle/java2d/ToPictureSpec.scala
@@ -1,6 +1,7 @@
 package doodle
 package java2d
 
+import cats.effect.unsafe.implicits.global
 import doodle.algebra.ToPicture
 import doodle.core.{Base64 => B64}
 import doodle.effect.Writer._

--- a/java2d/src/test/scala/doodle/java2d/WriterSpec.scala
+++ b/java2d/src/test/scala/doodle/java2d/WriterSpec.scala
@@ -1,6 +1,7 @@
 package doodle
 package java2d
 
+import cats.effect.unsafe.implicits.global
 import doodle.effect.Writer._
 import doodle.syntax._
 import minitest._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "1.6.0")
+addSbtPlugin("org.scala-js"              % "sbt-scalajs"              % "1.7.0")
 addSbtPlugin("com.dwijnand"              % "sbt-travisci"             % "1.1.0")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-git"                  % "0.9.3")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"               % "5.6.0")

--- a/reactor/jvm/src/main/scala/doodle/reactor/examples/Easing.scala
+++ b/reactor/jvm/src/main/scala/doodle/reactor/examples/Easing.scala
@@ -2,10 +2,10 @@ package doodle
 package reactor
 package examples
 
+import cats.effect.unsafe.implicits.global
 import doodle.core._
 import doodle.image.Image
 import doodle.java2d._
-import monix.execution.Scheduler.Implicits.global
 
 object Easing {
   def easeIn(t: Double): Double =

--- a/reactor/shared/src/main/scala/doodle/reactor/BaseReactor.scala
+++ b/reactor/shared/src/main/scala/doodle/reactor/BaseReactor.scala
@@ -1,6 +1,8 @@
 package doodle
 package reactor
 
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.instances.unit._
 import doodle.core.Point
 import doodle.effect.Renderer
@@ -12,8 +14,7 @@ import doodle.interact.effect.AnimationRenderer
 import doodle.interact.syntax._
 import doodle.language.Basic
 import doodle.syntax.renderer._
-import monix.execution.Scheduler
-import monix.reactive.Observable
+import fs2.Stream
 
 import scala.concurrent.duration._
 
@@ -40,7 +41,10 @@ trait BaseReactor[A] {
     */
   def tick[F[_], Frame, Canvas](
       frame: Frame
-  )(implicit e: Renderer[Basic, F, Frame, Canvas]): Option[A] = {
+  )(implicit
+      e: Renderer[Basic, F, Frame, Canvas],
+      runtime: IORuntime
+  ): Option[A] = {
     if (stop(initial)) None
     else {
       (render(initial)).draw(frame)
@@ -56,35 +60,34 @@ trait BaseReactor[A] {
       a: AnimationRenderer[Canvas],
       e: Renderer[Alg, F, Frame, Canvas],
       m: MouseClick[Canvas] with MouseMove[Canvas],
-      s: Scheduler
+      runtime: IORuntime
   ): Unit = {
     import BaseReactor._
-
-    implicit val strategy = monix.reactive.OverflowStrategy.DropOld(10)
 
     frame
       .canvas[Alg, F, Canvas]()
       .flatMap { canvas =>
-        val mouseMove: Observable[Command] =
+        val mouseMove: Stream[IO, Command] =
           canvas.mouseMove.map(pt => MouseMove(pt))
-        val mouseClick: Observable[Command] =
+        val mouseClick: Stream[IO, Command] =
           canvas.mouseClick.map(pt => MouseClick(pt))
-        val tick: Observable[Command] =
-          Observable.interval(this.tickRate).map(_ => Tick)
-        val frames = Observable(tick, mouseClick, mouseMove).merge
-          .flatScan0(this.initial) { (a, cmd) =>
-            if (this.stop(a)) Observable.empty
-            else
-              cmd match {
-                case Tick           => Observable(this.onTick(a))
-                case MouseMove(pt)  => Observable(this.onMouseMove(pt, a))
-                case MouseClick(pt) => Observable(this.onMouseClick(pt, a))
-              }
+        val tick: Stream[IO, Command] =
+          Stream.fixedDelay[IO](this.tickRate).map(_ => Tick)
+        val frames = tick
+          .merge(mouseMove)
+          .merge(mouseClick)
+          .scan(this.initial) { (a, cmd) =>
+            cmd match {
+              case Tick           => this.onTick(a)
+              case MouseMove(pt)  => this.onMouseMove(pt, a)
+              case MouseClick(pt) => this.onMouseClick(pt, a)
+            }
           }
+          .takeWhile(a => !this.stop(a))
           .map(a => Image.compile[Alg, F](this.render(a)))
         frames.animateWithCanvasToIO(canvas)
       }
-      .unsafeRunAsyncAndForget()
+      .unsafeRunAsync(_ => ())
   }
 }
 object BaseReactor {

--- a/reactor/shared/src/main/scala/doodle/reactor/Reactor.scala
+++ b/reactor/shared/src/main/scala/doodle/reactor/Reactor.scala
@@ -1,6 +1,7 @@
 package doodle
 package reactor
 
+import cats.effect.unsafe.IORuntime
 import doodle.core.Point
 import doodle.effect._
 import doodle.image.Image
@@ -67,16 +68,20 @@ final case class Reactor[A](
 
   def draw[Alg[x[_]] <: Basic[x], F[_], Frame, Canvas](
       frame: Frame
-  )(implicit renderer: Renderer[Alg, F, Frame, Canvas]): Unit = {
+  )(implicit
+      renderer: Renderer[Alg, F, Frame, Canvas],
+      runtime: IORuntime
+  ): Unit = {
     import doodle.image.syntax._
-    this.image.draw(frame)(renderer)
+    this.image.draw(frame)(renderer, runtime)
   }
 
   def draw[Alg[x[_]] <: Basic[x], F[_], Frame, Canvas]()(implicit
-      renderer: DefaultRenderer[Alg, F, Frame, Canvas]
+      renderer: DefaultRenderer[Alg, F, Frame, Canvas],
+      runtime: IORuntime
   ): Unit = {
     import doodle.image.syntax._
-    this.image.draw()(renderer)
+    this.image.draw()(renderer, runtime)
   }
 }
 object Reactor {


### PR DESCRIPTION
This is a WIP upgrade to cats effect 3, replacing Monix with fs2. It addresses #106 .

# A brief overview

Most of the minor changes are a simple rename from `Observable[A]` to `Stream[IO, A]`. The `Observable` time-based throttling functions (such as `throttle`, `interval`, `sample`) all seem to have fairly direct equivalents in fs2.  

The CE3 upgrade also requires an implicit `IORuntime`. The examples and demos use the `IORuntime` of `cats.effect.unsafe.implicits.global`.

The major logic change relates to the event listeners in the `java2d.effect.Canvas` class. These now use a circular buffer queue to convert from a "hot" event handlers to "cold" streams.

The only thing outstanding (I think) is the behaviour of the `MouseOver` algebra. I don't think anything uses this yet, so have been a bit reluctant to implement it.

I've spot checked the demos and images, and everything seems to be working correctly. The code compiles and the tests mostly pass - I've some `node` issues locally so haven't yet tested the `JS` code.