### PR TITLE
Add margin support to Image

### DIFF
--- a/image/shared/src/main/scala/doodle/image/Image.scala
+++ b/image/shared/src/main/scala/doodle/image/Image.scala
@@ -41,6 +41,20 @@ sealed abstract class Image extends Product with Serializable {
   def below(top: Image): Image =
     Above(top, this)
 
+  def margin(
+              top: Double,
+              right: Double,
+              bottom: Double,
+              left: Double
+            ) : Image =
+    Margin(this, top, right, bottom, left)
+
+  def margin(width: Double, height: Double) : Image =
+    Margin(this, height, width, height, width)
+
+  def margin(width: Double) : Image =
+    Margin(this, width, width, width, width)
+
   // Context Transform ------------------------------------------------
 
   def strokeColor(color: Color): Image =
@@ -173,6 +187,7 @@ object Image {
     final case class On(t: Image, b: Image) extends Image
     final case class At(image: Image, x: Double, y: Double) extends Image
     final case class Transform(tx: core.Transform, i: Image) extends Image
+    final case class Margin(i: Image, top: Double, right: Double, bottom: Double, left: Double) extends Image
     // Style
     final case class StrokeWidth(image: Image, width: Double) extends Image
     final case class StrokeColor(image: Image, color: Color) extends Image
@@ -334,6 +349,8 @@ object Image {
             algebra.on(compile(t)(algebra), compile(b)(algebra))
           case At(image, x, y) =>
             algebra.at(compile(image)(algebra), x, y)
+          case Margin(image, top, right, bottom, left) =>
+            algebra.margin(compile(image)(algebra), top, right, bottom, left)
 
           case Transform(tx, i) =>
             algebra.transform(compile(i)(algebra), tx)


### PR DESCRIPTION
### Added margin support to Image (Issue #122)

- Tested it on several cases, and it works as expected. One of the test cases was the _rollingCircles_ from the Doodle Documentation (end of the Layout section);
- Overloaded margin method - it allows more flexibility in specifying margins by accepting 1, 2, or 4 arguments (just like in Picture).

Here is the example itself, but with the Picture replaced by Image:
`val circle = Image.circle(50)
    val rollingCircles =
      circle
        .margin(25)
        .debug
        .beside(circle.margin(15).debug)
        .beside(circle.debug)
        .beside(circle.margin(-15).debug)
        .beside(circle.margin(-25).debug)

    rollingCircles.draw()`
    
And here is the result:
![photo_2023-03-24_16-30-41](https://user-images.githubusercontent.com/72448226/227553844-1c027455-e06f-454e-9c48-32b02b4cffee.jpg)

This is my very first PR, so please let me know if I did something in the wrong way 