### PR TITLE
Added originAt support to Image

### DIFF
--- a/docs/src/pages/pictures/layout.md
+++ b/docs/src/pages/pictures/layout.md
@@ -141,4 +141,4 @@ val rollingCircles =
 
 ## Implementation
 
-The `Layout` algebra supports all the features described above. `Image` doesn't support `originAt`, or landmarks.
+The `Layout` algebra supports all the features described above. `Image` doesn't support landmarks.

--- a/image/shared/src/main/scala/doodle/image/Image.scala
+++ b/image/shared/src/main/scala/doodle/image/Image.scala
@@ -131,8 +131,19 @@ sealed abstract class Image extends Product with Serializable {
     At(this, pt.x, pt.y)
   }
 
+  def originAt(vec: Vec): Image =
+    OriginAt(this, vec.x, vec.y)
+
+  def originAt(pt: Point): Image =
+    OriginAt(this, pt.x, pt.y)
+
   def originAt(x: Double, y: Double): Image =
     OriginAt(this, x, y)
+
+  def originAt(r: Double, a: Angle): Image = {
+    val pt = Point(r, a)
+    OriginAt(this, pt.x, pt.y)
+  }
 
   // Debug ------------------------------------------------------------
 

--- a/image/shared/src/main/scala/doodle/image/Image.scala
+++ b/image/shared/src/main/scala/doodle/image/Image.scala
@@ -131,6 +131,9 @@ sealed abstract class Image extends Product with Serializable {
     At(this, pt.x, pt.y)
   }
 
+  def originAt(x: Double, y: Double): Image =
+    OriginAt(this, x, y)
+
   // Debug ------------------------------------------------------------
 
   def debug(color: Color): Image =
@@ -194,6 +197,7 @@ object Image {
         bottom: Double,
         left: Double
     ) extends Image
+    final case class OriginAt(image: Image, x: Double, y: Double) extends Image
     // Style
     final case class StrokeWidth(image: Image, width: Double) extends Image
     final case class StrokeColor(image: Image, color: Color) extends Image
@@ -357,6 +361,8 @@ object Image {
             algebra.at(compile(image)(algebra), x, y)
           case Margin(image, top, right, bottom, left) =>
             algebra.margin(compile(image)(algebra), top, right, bottom, left)
+          case OriginAt(image, x, y) =>
+            algebra.originAt(compile(image)(algebra), x, y)
 
           case Transform(tx, i) =>
             algebra.transform(compile(i)(algebra), tx)


### PR DESCRIPTION
### Added `originAt` support to `Image` (Issue #122)

Method works correctly and can take `Vec`, `Point`, x and y coordinates and polar coordinates just like the `originAt` in `Picture`.

Example with x, y coordinates:

```scala
val atAndOriginAt =
      Image
        .circle(100)
        .at(25, 25)
        .debug
        .beside(Image.circle(100).originAt(25, 25).debug)
```

Output:
![image](https://user-images.githubusercontent.com/72448226/227718743-e360a557-b75a-47b6-816a-84db2262319c.png)

I've also updated the docs.