### PR TITLE
Enable minitest and fix CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val commonSettings = Seq(
     Dependencies.miniTest.value,
     Dependencies.miniTestLaws.value
   ),
+  testFrameworks += new TestFramework("minitest.runner.Framework"),
   // scalacOptions ++= Seq("-release", "8"),
   // javacOptions ++= Seq("-source", "8", "-target", "8"),
   startYear := Some(2015),

--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,8 @@ lazy val docs =
           css,
           laikaSite
         )
-        .value
+        .value,
+      tlFatalWarnings := false
     )
     .enablePlugins(TypelevelSitePlugin)
     .dependsOn(core.jvm, image.jvm)

--- a/core/shared/src/main/scala/doodle/algebra/generic/package.scala
+++ b/core/shared/src/main/scala/doodle/algebra/generic/package.scala
@@ -20,7 +20,6 @@ package algebra
 import cats.*
 import cats.data.*
 import cats.syntax.all.*
-import doodle.core.BoundingBox
 import doodle.core.{Transform => Tx}
 
 package object generic {

--- a/core/shared/src/test/scala/doodle/algebra/generic/LayoutSpec.scala
+++ b/core/shared/src/test/scala/doodle/algebra/generic/LayoutSpec.scala
@@ -35,7 +35,6 @@ object LayoutSpec extends Properties("Layout properties") {
   property("hand generated path bounding boxes are correct") = {
     import doodle.core._
     import doodle.syntax.approximatelyEqual._
-    import doodle.algebra.generic._
     import Instances._
 
     implicit val algebra = TestAlgebra()

--- a/core/shared/src/test/scala/doodle/algebra/generic/TestAlgebra.scala
+++ b/core/shared/src/test/scala/doodle/algebra/generic/TestAlgebra.scala
@@ -71,8 +71,6 @@ final case class TestAlgebra(
     }
 }
 object TestAlgebra {
-  import doodle.algebra._
-
   type Algebra =
     Layout with Size with Path with Shape with Debug with Style with Text
   type Drawing[A] = Finalized[Reification, A]

--- a/core/shared/src/test/scala/doodle/algebra/generic/reified/Reified.scala
+++ b/core/shared/src/test/scala/doodle/algebra/generic/reified/Reified.scala
@@ -19,9 +19,6 @@ package algebra
 package generic
 package reified
 
-import cats.implicits._
-import doodle.algebra.generic.Fill
-import doodle.algebra.generic.Stroke
 import doodle.core.PathElement
 import doodle.core.Point
 import doodle.core.font.Font

--- a/golden/src/test/scala/doodle/golden/GoldenImage.scala
+++ b/golden/src/test/scala/doodle/golden/GoldenImage.scala
@@ -43,8 +43,9 @@ trait GoldenImage extends Golden { self: FunSuite =>
           .map(_ => imageDiff(file, temp))
           .unsafeRunSync()
       } finally {
-        if (temp.exists()) temp.delete()
-        ()
+        if (temp.exists())
+          temp.delete()
+          ()
       }
     } else {
       println(s"Golden: ${file} does not exist. Creating golden image.")

--- a/golden/src/test/scala/doodle/golden/GoldenPicture.scala
+++ b/golden/src/test/scala/doodle/golden/GoldenPicture.scala
@@ -44,8 +44,9 @@ trait GoldenPicture extends Golden { self: FunSuite =>
 
         imageDiff(file, temp)
       } finally {
-        if (temp.exists()) temp.delete()
-        ()
+        if (temp.exists())
+          temp.delete()
+          ()
       }
     } else {
       println(s"Golden: ${file} does not exist. Creating golden image.")

--- a/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
+++ b/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
@@ -25,7 +25,6 @@ import doodle.core.format.Format
 import doodle.core.{Base64 => B64}
 import doodle.effect.Base64
 import doodle.effect.Writer
-import doodle.image.Image
 import doodle.language.Basic
 
 import java.io.File

--- a/image/shared/src/main/scala-2.13/doodle/image/examples/Mandelbrot.scala
+++ b/image/shared/src/main/scala-2.13/doodle/image/examples/Mandelbrot.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 import doodle.syntax.angle._
 
 // Mandelbrot Fractal

--- a/image/shared/src/main/scala/doodle/image/examples/GradientCircles.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/GradientCircles.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 
 object GradientCircles {
   val grad = Gradient.dichromaticRadial(Color.red, Color.blue, 100.0)

--- a/image/shared/src/main/scala/doodle/image/examples/Koch.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Koch.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.instances.all._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/Layers.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Layers.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.implicits._
 import doodle.core._
-import doodle.image.Image
 import doodle.random._
 
 object Layers {

--- a/image/shared/src/main/scala/doodle/image/examples/Layout.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Layout.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 
 object Layout {
   // Examples for debugging layout

--- a/image/shared/src/main/scala/doodle/image/examples/OpenClosedPaths.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/OpenClosedPaths.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 
 object OpenClosedPaths {
   val openCurve = OpenPath.empty.curveTo(

--- a/image/shared/src/main/scala/doodle/image/examples/ParametricSamples.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/ParametricSamples.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.instances.list._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/ParticleSystem.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/ParticleSystem.scala
@@ -26,7 +26,6 @@ import cats.Monoid
 import cats.data.Kleisli
 import cats.data.WriterT
 import cats.implicits._
-import doodle.image.Image
 
 object ParticleSystem {
 

--- a/image/shared/src/main/scala/doodle/image/examples/Polygon.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Polygon.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.instances.list._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/RainbowSierpinski.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/RainbowSierpinski.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 import doodle.syntax.all._
 
 object RainbowSierpinski {

--- a/image/shared/src/main/scala/doodle/image/examples/Sierpinski.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Sierpinski.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 
 object Sierpinski {
   def triangle(size: Double): Image = {

--- a/image/shared/src/main/scala/doodle/image/examples/SierpinskiConfection.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/SierpinskiConfection.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 import doodle.random._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/SierpinskiRipple.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/SierpinskiRipple.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 import doodle.syntax.all._
 
 object SierpinskiRipple {

--- a/image/shared/src/main/scala/doodle/image/examples/Sine.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Sine.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.implicits._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.Image._
 import doodle.image.syntax.all._
 import doodle.image.syntax.core._

--- a/image/shared/src/main/scala/doodle/image/examples/Smoke.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Smoke.scala
@@ -19,7 +19,6 @@ package image
 package examples
 
 import doodle.core._
-import doodle.image.Image
 import doodle.random._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/Stars.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Stars.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.instances.list._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/examples/Street.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Street.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.instances.list._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 
 object Street {

--- a/image/shared/src/main/scala/doodle/image/examples/Tiles.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Tiles.scala
@@ -21,7 +21,6 @@ package examples
 import cats.instances.all._
 import cats.syntax.all._
 import doodle.core._
-import doodle.image.Image
 import doodle.image.syntax.all._
 import doodle.random._
 import doodle.syntax.all._

--- a/image/shared/src/main/scala/doodle/image/examples/Windswept.scala
+++ b/image/shared/src/main/scala/doodle/image/examples/Windswept.scala
@@ -20,7 +20,6 @@ package examples
 
 import cats.syntax.all._
 import doodle.core._
-import doodle.image.Image
 import doodle.random._
 import doodle.syntax.all._
 

--- a/image/shared/src/main/scala/doodle/image/syntax/AbstractImageSyntax.scala
+++ b/image/shared/src/main/scala/doodle/image/syntax/AbstractImageSyntax.scala
@@ -21,7 +21,6 @@ package syntax
 import cats.effect.unsafe.IORuntime
 import doodle.effect.DefaultRenderer
 import doodle.effect.Renderer
-import doodle.image.Image
 import doodle.language.Basic
 import doodle.syntax.AbstractRendererSyntax
 

--- a/java2d/src/main/scala/doodle/java2d/algebra/reified/Reified.scala
+++ b/java2d/src/main/scala/doodle/java2d/algebra/reified/Reified.scala
@@ -19,7 +19,6 @@ package java2d
 package algebra
 package reified
 
-import cats.implicits._
 import doodle.algebra.generic.Fill
 import doodle.algebra.generic.Stroke
 import doodle.core.PathElement


### PR DESCRIPTION
I was playing around with the Color class and noticed that my changes do not fail any tests. Apparently, the minitest suites were disabled in https://github.com/creativescala/doodle/commit/e9d3e46a4d15a456db3d03353d79f9b638ca1863. 

This change enables them again. I've also took upon fixing the build, which required removing redundant imports and loosening up on fatal warnings in the docs build.

Feel free to close if I do not have the full context and the tests are disabled by design.