### PR TITLE
Add consistent naming of writers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.watcherExclude": {
-        "**/target": true
-    }
-}

--- a/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
+++ b/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
@@ -15,28 +15,16 @@
  */
 
 package doodle
-package syntax
+package effect
 
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
-import doodle.effect.BufferedImageConverter
 import java.awt.image.BufferedImage
 
-trait BufferedImageConverterSyntax {
-  implicit class BufferedImageConverterOps[Alg <: Algebra, A](
+trait BufferedImageWriter[+Alg <: Algebra, Frame] {
+  def bufferedImage[A](
+      description: Frame,
       picture: Picture[Alg, A]
-  ) {
-    def bufferedImage[Frame](frame: Frame)(implicit
-        w: BufferedImageConverter[Alg, Frame],
-        r: IORuntime
-    ): (A, BufferedImage) =
-      w.bufferedImage(frame, picture).unsafeRunSync()
-
-    def bufferedImageToIO[Frame](frame: Frame)(implicit
-        w: BufferedImageConverter[Alg, Frame]
-    ): IO[(A, BufferedImage)] =
-      w.bufferedImage(frame, picture)
-  }
+  ): IO[(A, BufferedImage)]
 }

--- a/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
+++ b/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
@@ -22,6 +22,9 @@ import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import java.awt.image.BufferedImage
 
+/** The BufferedImageWriter type represent the ability to encode an image as a
+  * java BufferedImage class.
+  */
 trait BufferedImageWriter[+Alg <: Algebra, Frame] extends Writer[Alg, Frame] {
   def bufferedImage[A](
       description: Frame,

--- a/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
+++ b/core/jvm/src/main/scala/doodle/effect/BufferedImageWriter.scala
@@ -22,7 +22,7 @@ import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import java.awt.image.BufferedImage
 
-trait BufferedImageWriter[+Alg <: Algebra, Frame] {
+trait BufferedImageWriter[+Alg <: Algebra, Frame] extends Writer[Alg, Frame] {
   def bufferedImage[A](
       description: Frame,
       picture: Picture[Alg, A]

--- a/core/jvm/src/main/scala/doodle/syntax/Base64WriterSyntax.scala
+++ b/core/jvm/src/main/scala/doodle/syntax/Base64WriterSyntax.scala
@@ -23,9 +23,9 @@ import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.core.format.Format
 import doodle.core.{Base64 => B64}
-import doodle.effect.Base64
+import doodle.effect.Base64Writer
 
-trait Base64Syntax {
+trait Base64WriterSyntax {
   implicit class Base64Ops[Alg <: Algebra, A](
       picture: Picture[Alg, A]
   ) {
@@ -33,13 +33,13 @@ trait Base64Syntax {
     // type parameter when calling syntax methods.
     class Base64OpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
       def apply[Frame]()(implicit
-          w: Base64[Alg, Frame, Fmt],
+          w: Base64Writer[Alg, Frame, Fmt],
           r: IORuntime
       ): (A, B64[Fmt]) =
         w.base64(picture).unsafeRunSync()
 
       def apply[Frame](frame: Frame)(implicit
-          w: Base64[Alg, Frame, Fmt],
+          w: Base64Writer[Alg, Frame, Fmt],
           r: IORuntime
       ): (A, B64[Fmt]) =
         w.base64(frame, picture).unsafeRunSync()
@@ -47,12 +47,12 @@ trait Base64Syntax {
 
     class Base64IOOpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
       def apply[Frame]()(implicit
-          w: Base64[Alg, Frame, Fmt]
+          w: Base64Writer[Alg, Frame, Fmt]
       ): IO[(A, B64[Fmt])] =
         w.base64(picture)
 
       def apply[Frame](frame: Frame)(implicit
-          w: Base64[Alg, Frame, Fmt]
+          w: Base64Writer[Alg, Frame, Fmt]
       ): IO[(A, B64[Fmt])] =
         w.base64(frame, picture)
     }

--- a/core/jvm/src/main/scala/doodle/syntax/BufferedImageWriterSyntax.scala
+++ b/core/jvm/src/main/scala/doodle/syntax/BufferedImageWriterSyntax.scala
@@ -15,16 +15,28 @@
  */
 
 package doodle
-package effect
+package syntax
 
 import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
+import doodle.effect.BufferedImageWriter
 import java.awt.image.BufferedImage
 
-trait BufferedImageConverter[+Alg <: Algebra, Frame] {
-  def bufferedImage[A](
-      description: Frame,
+trait BufferedImageWriterSyntax {
+  implicit class BufferedImageWriterOps[Alg <: Algebra, A](
       picture: Picture[Alg, A]
-  ): IO[(A, BufferedImage)]
+  ) {
+    def bufferedImage[Frame](frame: Frame)(implicit
+        w: BufferedImageWriter[Alg, Frame],
+        r: IORuntime
+    ): (A, BufferedImage) =
+      w.bufferedImage(frame, picture).unsafeRunSync()
+
+    def bufferedImageToIO[Frame](frame: Frame)(implicit
+        w: BufferedImageWriter[Alg, Frame]
+    ): IO[(A, BufferedImage)] =
+      w.bufferedImage(frame, picture)
+  }
 }

--- a/core/jvm/src/main/scala/doodle/syntax/FileWriterSyntax.scala
+++ b/core/jvm/src/main/scala/doodle/syntax/FileWriterSyntax.scala
@@ -22,68 +22,68 @@ import cats.effect.unsafe.IORuntime
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.core.format.Format
-import doodle.effect.Writer
+import doodle.effect.FileWriter
 
 import java.io.File
 
-trait WriterSyntax {
+trait FileWriterSyntax {
   implicit class WriterOps[Alg <: Algebra, A](
       picture: Picture[Alg, A]
   ) {
     // This class exists solely so the user doesn't have to provide the `Frame`
     // type parameter when calling syntax methods.
-    class WriterOpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
+    class FileWriterOpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
       def apply[Frame](file: String)(implicit
-          w: Writer[Alg, Frame, Fmt],
+          w: FileWriter[Alg, Frame, Fmt],
           r: IORuntime
       ): A =
         apply(new File(file))
 
       def apply[Frame](file: File)(implicit
-          w: Writer[Alg, Frame, Fmt],
+          w: FileWriter[Alg, Frame, Fmt],
           r: IORuntime
       ): A =
         w.write(file, picture).unsafeRunSync()
 
       def apply[Frame](file: String, frame: Frame)(implicit
-          w: Writer[Alg, Frame, Fmt],
+          w: FileWriter[Alg, Frame, Fmt],
           r: IORuntime
       ): A =
         apply(new File(file), frame)
 
       def apply[Frame](file: File, frame: Frame)(implicit
-          w: Writer[Alg, Frame, Fmt],
+          w: FileWriter[Alg, Frame, Fmt],
           r: IORuntime
       ): A =
         w.write(file, frame, picture).unsafeRunSync()
     }
 
-    class WriterIOOpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
+    class FileWriterIOOpsHelper[Fmt <: Format](picture: Picture[Alg, A]) {
       def apply[Frame](file: String)(implicit
-          w: Writer[Alg, Frame, Fmt]
+          w: FileWriter[Alg, Frame, Fmt]
       ): IO[A] =
         apply(new File(file))
 
       def apply[Frame](file: File)(implicit
-          w: Writer[Alg, Frame, Fmt]
+          w: FileWriter[Alg, Frame, Fmt]
       ): IO[A] =
         w.write(file, picture)
 
       def apply[Frame](file: String, frame: Frame)(implicit
-          w: Writer[Alg, Frame, Fmt]
+          w: FileWriter[Alg, Frame, Fmt]
       ): IO[A] =
         apply(new File(file), frame)
 
       def apply[Frame](file: File, frame: Frame)(implicit
-          w: Writer[Alg, Frame, Fmt]
+          w: FileWriter[Alg, Frame, Fmt]
       ): IO[A] =
         w.write(file, frame, picture)
     }
 
     def write[Fmt <: Format] =
-      new WriterOpsHelper[Fmt](picture)
+      new FileWriterOpsHelper[Fmt](picture)
 
     def writeToIO[Fmt <: Format] =
-      new WriterIOOpsHelper[Fmt](picture)
+      new FileWriterIOOpsHelper[Fmt](picture)
   }
 }

--- a/core/jvm/src/main/scala/doodle/syntax/package.scala
+++ b/core/jvm/src/main/scala/doodle/syntax/package.scala
@@ -19,10 +19,10 @@ package doodle
 package object syntax {
   object all
       extends AngleSyntax
-      with Base64Syntax
+      with Base64WriterSyntax
       with BitmapSyntax
       with BlendSyntax
-      with BufferedImageConverterSyntax
+      with BufferedImageWriterSyntax
       with DebugSyntax
       with LayoutSyntax
       with NormalizedSyntax
@@ -36,12 +36,12 @@ package object syntax {
       with TransformSyntax
       with TraverseSyntax
       with UnsignedByteSyntax
-      with WriterSyntax
+      with FileWriterSyntax
   object angle extends AngleSyntax
-  object base64 extends Base64Syntax
+  object base64Writer extends Base64WriterSyntax
   object bitmap extends BitmapSyntax
   object blend extends BlendSyntax
-  object bufferedImageConverter extends BufferedImageConverterSyntax
+  object bufferedImageWriter extends BufferedImageWriterSyntax
   object debug extends DebugSyntax
   object layout extends LayoutSyntax
   object normalized extends NormalizedSyntax
@@ -55,5 +55,5 @@ package object syntax {
   object transform extends TransformSyntax
   object traverse extends TraverseSyntax
   object unsignedByte extends UnsignedByteSyntax
-  object writer extends WriterSyntax
+  object fileWriter extends FileWriterSyntax
 }

--- a/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
@@ -26,7 +26,7 @@ import doodle.core.{Base64 => B64}
 /** The Base64 type represent the ability to encode an image as a Base64 String
   * in a given format.
   */
-trait Base64[+Alg <: Algebra, Frame, Fmt <: Format] {
+trait Base64Writer[+Alg <: Algebra, Frame, Fmt <: Format] {
   def base64[A](
       description: Frame,
       picture: Picture[Alg, A]

--- a/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
@@ -26,7 +26,8 @@ import doodle.core.{Base64 => B64}
 /** The Base64 type represent the ability to encode an image as a Base64 String
   * in a given format.
   */
-trait Base64Writer[+Alg <: Algebra, Frame, Fmt <: Format] {
+trait Base64Writer[+Alg <: Algebra, Frame, Fmt <: Format]
+    extends Writer[Alg, Frame] {
   def base64[A](
       description: Frame,
       picture: Picture[Alg, A]

--- a/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Base64Writer.scala
@@ -23,8 +23,8 @@ import doodle.algebra.Picture
 import doodle.core.format.Format
 import doodle.core.{Base64 => B64}
 
-/** The Base64 type represent the ability to encode an image as a Base64 String
-  * in a given format.
+/** The Base64Writer type represent the ability to encode an image as a Base64
+  * String in a given format.
   */
 trait Base64Writer[+Alg <: Algebra, Frame, Fmt <: Format]
     extends Writer[Alg, Frame] {

--- a/core/shared/src/main/scala/doodle/effect/FileWriter.scala
+++ b/core/shared/src/main/scala/doodle/effect/FileWriter.scala
@@ -24,10 +24,10 @@ import doodle.core.format.Format
 
 import java.io.File
 
-/** The `Writer` typeclass represents write a picture to a file in a given
+/** The `FileWriter` typeclass represents write a picture to a file in a given
   * format.
   */
-trait Writer[+Alg <: Algebra, Frame, Fmt <: Format] {
+trait FileWriter[+Alg <: Algebra, Frame, Fmt <: Format] {
   def write[A](file: File, description: Frame, image: Picture[Alg, A]): IO[A]
   def write[A](file: File, image: Picture[Alg, A]): IO[A]
 }

--- a/core/shared/src/main/scala/doodle/effect/Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Writer.scala
@@ -17,18 +17,6 @@
 package doodle
 package effect
 
-import cats.effect.IO
 import doodle.algebra.Algebra
-import doodle.algebra.Picture
-import doodle.core.format.Format
 
-import java.io.File
-
-/** The `FileWriter` typeclass represents write a picture to a file in a given
-  * format.
-  */
-trait FileWriter[+Alg <: Algebra, Frame, Fmt <: Format]
-    extends Writer[Alg, Frame] {
-  def write[A](file: File, description: Frame, image: Picture[Alg, A]): IO[A]
-  def write[A](file: File, image: Picture[Alg, A]): IO[A]
-}
+trait Writer[+Alg <: Algebra, Frame]

--- a/core/shared/src/main/scala/doodle/effect/Writer.scala
+++ b/core/shared/src/main/scala/doodle/effect/Writer.scala
@@ -19,4 +19,6 @@ package effect
 
 import doodle.algebra.Algebra
 
+/** Marker trait for effects that write a picture to a file or some other type.
+  */
 trait Writer[+Alg <: Algebra, Frame]

--- a/docs/src/pages/concepts/effects.md
+++ b/docs/src/pages/concepts/effects.md
@@ -1,6 +1,6 @@
 # Effects
 
-In Doodle, an effect such as @:api(doodle.effect.Renderer) carries out the instructions in a `Picture`. In the case of `Renderer`, this is drawing the picture on the screen. Saving a `Picture` to a file is another very common effect.
+In Doodle, an effect such as @:api(doodle.effect.Renderer) carries out the instructions in a `Picture`. In the case of `Renderer`, this is drawing the picture on the screen. Converting a `Picture` to another type or saving it to a file are another very common effects managed by `Writers`, for example, a `Base64Writer` or a `FileWriter`.
 
 You will mostly interact with effects by convenient syntax. For example, when you call `draw` on a `Picture` you are using an effect via such a convenience.
 

--- a/docs/src/pages/effect/README.md
+++ b/docs/src/pages/effect/README.md
@@ -1,3 +1,5 @@
 # Effects
 
-A picture is a description of what should be drawn. An effect carries out the description by, for example, drawing a picture to the screen or writing it to a file. Effects are defined in the @:api(doodle.effect.index) package. All effects have @:api(doodle.syntax.index) that makes them easier to use. You should not have to use effects directly unless you are extending Doodle.
+A picture is a description of what should be drawn. An effect carries out the description by, for example, drawing a picture to the screen. Another example includes converting a picture to a different type or saving it to a file which is managed by a special class of effects called `Writers`.
+
+Effects are defined in the @:api(doodle.effect.index) package. All effects have @:api(doodle.syntax.index) that makes them easier to use. You should not have to use effects directly unless you are extending Doodle.

--- a/golden/src/test/scala/doodle/golden/GoldenPicture.scala
+++ b/golden/src/test/scala/doodle/golden/GoldenPicture.scala
@@ -21,7 +21,7 @@ import cats.effect.unsafe.implicits.global
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import doodle.core.format._
-import doodle.effect.Writer
+import doodle.effect.FileWriter
 import doodle.java2d._
 import munit._
 
@@ -32,7 +32,7 @@ trait GoldenPicture extends Golden { self: FunSuite =>
       name: String,
       picture: Picture[Alg, Unit],
       frame: Frame = Frame.default.withSizedToPicture()
-  )(implicit loc: Location, w: Writer[Alg, Frame, Png]) = {
+  )(implicit loc: Location, w: FileWriter[Alg, Frame, Png]) = {
     import java.io.File
     val file = new File(s"${goldenDir}/${name}.png")
 
@@ -56,7 +56,7 @@ trait GoldenPicture extends Golden { self: FunSuite =>
 
   def testPicture[Alg <: Algebra, A](name: String)(
       picture: Picture[Alg, Unit]
-  )(implicit loc: Location, w: Writer[Alg, Frame, Png]) =
+  )(implicit loc: Location, w: FileWriter[Alg, Frame, Png]) =
     test(name) {
       assertGoldenPicture(name, picture)
     }
@@ -65,7 +65,7 @@ trait GoldenPicture extends Golden { self: FunSuite =>
       frame: Frame
   )(
       picture: Picture[Alg, Unit]
-  )(implicit loc: Location, w: Writer[Alg, Frame, Png]) =
+  )(implicit loc: Location, w: FileWriter[Alg, Frame, Png]) =
     test(name) {
       assertGoldenPicture(name, picture, frame)
     }

--- a/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
+++ b/image/jvm/src/main/scala/doodle/image/syntax/JvmImageSyntax.scala
@@ -23,8 +23,8 @@ import cats.effect.unsafe.IORuntime
 import doodle.algebra.Picture
 import doodle.core.format.Format
 import doodle.core.{Base64 => B64}
-import doodle.effect.Base64
-import doodle.effect.Writer
+import doodle.effect.Base64Writer
+import doodle.effect.FileWriter
 import doodle.language.Basic
 
 import java.io.File
@@ -40,7 +40,7 @@ class JvmImageSyntax extends AbstractImageSyntax(doodle.syntax.renderer) {
     */
   final class Base64Ops[Fmt <: Format](image: Image) {
     def apply[Alg <: Basic, Frame](implicit
-        w: Base64[Alg, Frame, Fmt],
+        w: Base64Writer[Alg, Frame, Fmt],
         runtime: IORuntime
     ): B64[Fmt] = {
       val picture = new Picture[Basic, Unit] {
@@ -52,7 +52,7 @@ class JvmImageSyntax extends AbstractImageSyntax(doodle.syntax.renderer) {
     }
   }
 
-  import doodle.syntax.writer._
+  import doodle.syntax.fileWriter._
 
   implicit class ImageWriterOps(image: Image) {
     def write[Fmt <: Format] = new ImageWriterUnitOps[Fmt](image)
@@ -65,24 +65,24 @@ class JvmImageSyntax extends AbstractImageSyntax(doodle.syntax.renderer) {
     */
   final class ImageWriterUnitOps[Fmt <: Format](image: Image) {
     def apply[Alg <: Basic, Frame](file: String)(implicit
-        w: Writer[Alg, Frame, Fmt],
+        w: FileWriter[Alg, Frame, Fmt],
         r: IORuntime
     ): Unit =
       apply(new File(file))
 
     def apply[Alg <: Basic, Frame](file: String, frame: Frame)(implicit
-        w: Writer[Alg, Frame, Fmt],
+        w: FileWriter[Alg, Frame, Fmt],
         r: IORuntime
     ): Unit =
       apply(new File(file), frame)
 
     def apply[Alg <: Basic, Frame](
         file: File
-    )(implicit w: Writer[Alg, Frame, Fmt], r: IORuntime): Unit =
+    )(implicit w: FileWriter[Alg, Frame, Fmt], r: IORuntime): Unit =
       image.compile[Alg].write[Fmt](file)
 
     def apply[Alg <: Basic, Frame](file: File, frame: Frame)(implicit
-        w: Writer[Alg, Frame, Fmt],
+        w: FileWriter[Alg, Frame, Fmt],
         r: IORuntime
     ): Unit =
       image.compile[Alg].write[Fmt](file, frame)
@@ -94,22 +94,22 @@ class JvmImageSyntax extends AbstractImageSyntax(doodle.syntax.renderer) {
     */
   final class ImageWriterIOOps[Fmt <: Format](image: Image) {
     def apply[Alg <: Basic, Frame](file: String)(implicit
-        w: Writer[Alg, Frame, Fmt]
+        w: FileWriter[Alg, Frame, Fmt]
     ): IO[Unit] =
       apply(new File(file))
 
     def apply[Alg <: Basic, Frame](file: String, frame: Frame)(implicit
-        w: Writer[Alg, Frame, Fmt]
+        w: FileWriter[Alg, Frame, Fmt]
     ): IO[Unit] =
       apply(new File(file), frame)
 
     def apply[Alg <: Basic, Frame](
         file: File
-    )(implicit w: Writer[Alg, Frame, Fmt]): IO[Unit] =
+    )(implicit w: FileWriter[Alg, Frame, Fmt]): IO[Unit] =
       image.compile[Alg].writeToIO[Fmt](file)
 
     def apply[Alg <: Basic, Frame](file: File, frame: Frame)(implicit
-        w: Writer[Alg, Frame, Fmt]
+        w: FileWriter[Alg, Frame, Fmt]
     ): IO[Unit] =
       image.compile[Alg].writeToIO[Fmt](file, frame)
   }

--- a/interact/shared/src/main/scala/doodle/interact/effect/AnimationWriter.scala
+++ b/interact/shared/src/main/scala/doodle/interact/effect/AnimationWriter.scala
@@ -23,13 +23,15 @@ import cats.effect.IO
 import doodle.algebra.Algebra
 import doodle.algebra.Picture
 import fs2.Stream
+import doodle.effect.Writer
 
 import java.io.File
 
 /** The `AnimationWriter` typeclass describes a data type that can write an
   * animation to a file.
   */
-trait AnimationWriter[Alg <: Algebra, Frame, Format] {
+trait AnimationWriter[Alg <: Algebra, Frame, Format]
+    extends Writer[Alg, Frame] {
 
   def write[A](
       file: File,

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dAnimationWriter.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dAnimationWriter.scala
@@ -49,7 +49,7 @@ object Java2dAnimationWriter
       a <- frames
         .evalMap { picture =>
           for {
-            result <- doodle.java2d.effect.Java2dWriter
+            result <- doodle.java2d.effect.Java2d
               .renderBufferedImage(
                 frame.size,
                 frame.center,

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dBufferedImageWriter.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dBufferedImageWriter.scala
@@ -15,20 +15,29 @@
  */
 
 package doodle
+package java2d
 package effect
 
 import cats.effect.IO
-import doodle.algebra.Algebra
-import doodle.algebra.Picture
-import doodle.core.format.Format
+import doodle.effect.*
+import doodle.java2d.effect.{Java2d => Java2dEffect}
+import java.awt.image.BufferedImage
 
-import java.io.File
+object Java2dBufferedImageWriter
+    extends BufferedImageWriter[doodle.java2d.Algebra, Frame] {
+  def makeImage(width: Int, height: Int): BufferedImage =
+    new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
 
-/** The `FileWriter` typeclass represents write a picture to a file in a given
-  * format.
-  */
-trait FileWriter[+Alg <: Algebra, Frame, Fmt <: Format]
-    extends Writer[Alg, Frame] {
-  def write[A](file: File, description: Frame, image: Picture[Alg, A]): IO[A]
-  def write[A](file: File, image: Picture[Alg, A]): IO[A]
+  def bufferedImage[A](
+      frame: Frame,
+      picture: Picture[A]
+  ): IO[(A, BufferedImage)] = for {
+    result <- Java2dEffect.renderBufferedImage(
+      frame.size,
+      frame.center,
+      frame.background,
+      picture
+    )(makeImage _)
+    (bi, a) = result
+  } yield (a, bi)
 }

--- a/java2d/src/main/scala/doodle/java2d/effect/Java2dFileWriter.scala
+++ b/java2d/src/main/scala/doodle/java2d/effect/Java2dFileWriter.scala
@@ -42,9 +42,9 @@ import java.io.OutputStream
 import java.util.{Base64 => JBase64}
 import javax.imageio.ImageIO
 
-trait Java2dWriter[Fmt <: Format]
-    extends Writer[doodle.java2d.Algebra, Frame, Fmt]
-    with Base64[doodle.java2d.Algebra, Frame, Fmt] {
+trait Java2dFileWriter[Fmt <: Format]
+    extends FileWriter[doodle.java2d.Algebra, Frame, Fmt]
+    with Base64Writer[doodle.java2d.Algebra, Frame, Fmt] {
   def format: String
 
   // Allows formats to control the encoding of the buffered image. Not all
@@ -147,26 +147,26 @@ object Java2dWriter {
     } yield (image, a)
 
 }
-object Java2dGifWriter extends Java2dWriter[Gif] {
+object Java2dGifWriter extends Java2dFileWriter[Gif] {
   val format = "gif"
 
   def makeImage(width: Int, height: Int): BufferedImage =
     new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
 }
-object Java2dPngWriter extends Java2dWriter[Png] {
+object Java2dPngWriter extends Java2dFileWriter[Png] {
   val format = "png"
 
   def makeImage(width: Int, height: Int): BufferedImage =
     new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
 }
-object Java2dJpgWriter extends Java2dWriter[Jpg] {
+object Java2dJpgWriter extends Java2dFileWriter[Jpg] {
   val format = "jpeg"
 
   def makeImage(width: Int, height: Int): BufferedImage =
     new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
 }
 
-object Java2dPdfWriter extends Java2dWriter[Pdf] {
+object Java2dPdfWriter extends Java2dFileWriter[Pdf] {
   val format = "pdf"
 
   def makeImage(width: Int, height: Int): BufferedImage =
@@ -209,7 +209,7 @@ object Java2dPdfWriter extends Java2dWriter[Pdf] {
 }
 
 object Java2dBufferedImageWriter
-    extends BufferedImageConverter[doodle.java2d.Algebra, Frame] {
+    extends BufferedImageWriter[doodle.java2d.Algebra, Frame] {
   def makeImage(width: Int, height: Int): BufferedImage =
     new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
 

--- a/java2d/src/main/scala/doodle/java2d/package.scala
+++ b/java2d/src/main/scala/doodle/java2d/package.scala
@@ -18,15 +18,15 @@ package doodle
 
 import doodle.algebra._
 import doodle.core.format._
-import doodle.effect.Base64
+import doodle.effect.Base64Writer
 import doodle.effect.DefaultRenderer
-import doodle.effect.Writer
+import doodle.effect.FileWriter
 import doodle.interact.algebra._
 import doodle.interact.effect.AnimationRenderer
 import doodle.interact.effect.AnimationWriter
 import doodle.java2d.algebra.reified.Reification
 import doodle.language.Basic
-import doodle.effect.BufferedImageConverter
+import doodle.effect.BufferedImageWriter
 
 package object java2d extends Java2dToPicture {
   type Algebra =
@@ -55,19 +55,19 @@ package object java2d extends Java2dToPicture {
       : DefaultRenderer[Algebra, doodle.java2d.effect.Frame, Canvas] =
     doodle.java2d.effect.Java2dRenderer
   implicit val java2dGifWriter
-      : Writer[Algebra, Frame, Gif] with Base64[Algebra, Frame, Gif] =
+      : FileWriter[Algebra, Frame, Gif] with Base64Writer[Algebra, Frame, Gif] =
     doodle.java2d.effect.Java2dGifWriter
   implicit val java2dPngWriter
-      : Writer[Algebra, Frame, Png] with Base64[Algebra, Frame, Png] =
+      : FileWriter[Algebra, Frame, Png] with Base64Writer[Algebra, Frame, Png] =
     doodle.java2d.effect.Java2dPngWriter
   implicit val java2dJpgWriter
-      : Writer[Algebra, Frame, Jpg] with Base64[Algebra, Frame, Jpg] =
+      : FileWriter[Algebra, Frame, Jpg] with Base64Writer[Algebra, Frame, Jpg] =
     doodle.java2d.effect.Java2dJpgWriter
   implicit val java2dPdfWriter
-      : Writer[Algebra, Frame, Pdf] with Base64[Algebra, Frame, Pdf] =
+      : FileWriter[Algebra, Frame, Pdf] with Base64Writer[Algebra, Frame, Pdf] =
     doodle.java2d.effect.Java2dPdfWriter
   implicit val java2dBufferedImageWriter
-      : BufferedImageConverter[doodle.java2d.Algebra, Frame] =
+      : BufferedImageWriter[doodle.java2d.Algebra, Frame] =
     doodle.java2d.effect.Java2dBufferedImageWriter
 
   val Frame = doodle.java2d.effect.Frame

--- a/java2d/src/test/scala/doodle/java2d/Base64WriterSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/Base64WriterSuite.scala
@@ -23,7 +23,7 @@ import doodle.core.format.*
 import doodle.syntax.all.*
 import munit.FunSuite
 
-class Base64Suite extends FunSuite {
+class Base64WriterSuite extends FunSuite {
   def base64Distance[A <: Format](b1: Base64[A], b2: Base64[A]): Double = {
     import java.util.{Base64 => JBase64}
     val d1 = JBase64.getDecoder().decode(b1.value)

--- a/java2d/src/test/scala/doodle/java2d/FileWriterSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/FileWriterSuite.scala
@@ -24,7 +24,7 @@ import munit.FunSuite
 
 import java.io.File
 
-class WriterSuite extends FunSuite {
+class FileWriterSuite extends FunSuite {
   val image = circle[Algebra](20.0)
 
   test("write should work with png") {

--- a/java2d/src/test/scala/doodle/java2d/ToPictureSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/ToPictureSuite.scala
@@ -42,7 +42,7 @@ class ToPictureSuite extends FunSuite {
   def testInverse[A <: Format](
       picture: Picture[Unit]
   )(implicit
-      b: Base64[Algebra, Frame, A],
+      b: Base64Writer[Algebra, Frame, A],
       tp: ToPicture[B64[A], Algebra]
   ) = {
     val (_, b1) = picture.base64[A](Frame.default.withSizedToPicture(0))

--- a/svg/jvm/src/main/scala/doodle/svg/effect/SvgWriter.scala
+++ b/svg/jvm/src/main/scala/doodle/svg/effect/SvgWriter.scala
@@ -29,8 +29,8 @@ import java.nio.file.Files
 import java.util.{Base64 => JBase64}
 
 object SvgWriter
-    extends Writer[Algebra, Frame, format.Svg]
-    with Base64[Algebra, Frame, format.Svg] {
+    extends FileWriter[Algebra, Frame, format.Svg]
+    with Base64Writer[Algebra, Frame, format.Svg] {
   def write[A](
       file: File,
       description: Frame,

--- a/svg/jvm/src/main/scala/doodle/svg/package.scala
+++ b/svg/jvm/src/main/scala/doodle/svg/package.scala
@@ -17,7 +17,7 @@
 package doodle
 
 import doodle.core.format.Svg
-import doodle.effect.Writer
+import doodle.effect.FileWriter
 
 package object svg {
   val jvm = new doodle.svg.algebra.JvmAlgebraModule {}
@@ -32,7 +32,7 @@ package object svg {
   type Tag = jvm.Tag
   type Frame = doodle.svg.effect.Frame
   val Frame = doodle.svg.effect.Frame
-  implicit val svgWriter: Writer[Algebra, Frame, Svg] =
+  implicit val svgWriter: FileWriter[Algebra, Frame, Svg] =
     doodle.svg.effect.SvgWriter
 
   type Picture[A] = doodle.algebra.Picture[Algebra, A]


### PR DESCRIPTION
I renamed all "writing" effects to have a suffix `Writer`, updated sytax and moved `Java2dBuffereImageWriter` to a separate file. Additionally, I moved the `renderBufferedImage()` method from `Java2dWriter` to a `Java2d` as it is now used by multiple files. I decided not to proceed with creating a separate file to store all of the actuall writer objects as with the `renderBufferedImage()` method moved it seems to make more sense to leave them as they are (otherwise this file would become very large very quickly).

Closes #146 