### PR TITLE
Fixed Monospaced Fonts

### DIFF
--- a/svg/shared/src/main/scala/doodle/svg/algebra/Svg.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/Svg.scala
@@ -23,9 +23,9 @@ import cats.effect.IO
 import doodle.algebra.Picture
 import doodle.algebra.generic.Fill
 import doodle.algebra.generic.Stroke
-import doodle.core.*
+import doodle.core._
 import doodle.core.font.FontSize.Points
-import doodle.core.font.*
+import doodle.core.font._
 import doodle.svg.effect.Size
 
 import scala.collection.mutable
@@ -116,7 +116,7 @@ trait SvgModule { self: Base =>
         font.family match {
           case FontFamily.Serif       => "serif"
           case FontFamily.SansSerif   => "sans-serif"
-          case FontFamily.Monospaced  => "monospaced"
+          case FontFamily.Monospaced  => "monospace"
           case FontFamily.Named(name) => name
         }
 

--- a/svg/shared/src/test/scala/doodle/svg/effect/SvgSpec.scala
+++ b/svg/shared/src/test/scala/doodle/svg/effect/SvgSpec.scala
@@ -18,8 +18,8 @@ package doodle
 package svg
 package effect
 
-import doodle.algebra.generic.*
-import doodle.core.*
+import doodle.algebra.generic._
+import doodle.core._
 import doodle.language.Basic
 import munit.CatsEffectSuite
 
@@ -80,6 +80,19 @@ class SvgSpec
         ),
       path2
     )
+  }
+
+  test("monospaced fonts render correctly") {
+    import doodle.core.font.Font
+    import doodle.core.font.FontFamily
+
+    assertEquals(
+      Svg
+        .textTag("abc", Font.defaultSansSerif.family(FontFamily.monospaced))
+        .toString,
+      """<text font-family="monospace" style="font-style: normal;" font-size="12pt" font-weight="normal">abc</text>"""
+    )
+
   }
 
   test("paths of points render correctly") {


### PR DESCRIPTION
There is a bug in SVG font rendering whereby monospace fonts are not recognised. 

[The MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) specify that the family should be 'monospace', not 'monospaced'. 

Previous (monospaced):
![image](https://github.com/user-attachments/assets/fa634103-4045-4fd9-89a9-9d80e38792fb)

Current (monospace):
![image](https://github.com/user-attachments/assets/14cb9745-3647-4930-b0a2-59b6410919e6)
