### PR TITLE
completed textBoundingBox

### DIFF
--- a/canvas/src/main/scala/doodle/canvas/algebra/Text.scala
+++ b/canvas/src/main/scala/doodle/canvas/algebra/Text.scala
@@ -23,6 +23,8 @@ import doodle.core.Transform as Tx
 import doodle.core.font.Font
 import org.scalajs.dom
 
+import scala.scalajs.js
+
 trait Text extends GenericText[CanvasDrawing] {
   self: Algebra { type Drawing[A] = Finalized[CanvasDrawing, A] } =>
 
@@ -37,10 +39,36 @@ trait Text extends GenericText[CanvasDrawing] {
         text: String,
         bounds: Bounds
     ): CanvasDrawing[Unit] =
-      ???
+      ??? 
 
     def textBoundingBox(text: String, font: Font): (BoundingBox, Bounds) = {
-      ???
+      
+      val canvas =
+        dom.document.createElement("canvas").asInstanceOf[dom.html.Canvas]
+      val ctx =
+        canvas.getContext("2d").asInstanceOf[dom.CanvasRenderingContext2D]
+
+      
+      ctx.font = font.toString
+
+      
+      val metrics = ctx.measureText(text)
+
+      
+      val dynMetrics = metrics.asInstanceOf[js.Dynamic]
+      val left = dynMetrics.actualBoundingBoxLeft.asInstanceOf[Double]
+      val right = dynMetrics.actualBoundingBoxRight.asInstanceOf[Double]
+      val ascent = dynMetrics.actualBoundingBoxAscent.asInstanceOf[Double]
+      val descent = dynMetrics.actualBoundingBoxDescent.asInstanceOf[Double]
+
+      
+      
+      val x = -left
+      val y = -ascent
+      val width = left + right
+      val height = ascent + descent
+
+      (BoundingBox(x, y, width, height), metrics)
     }
   }
 }


### PR DESCRIPTION
issue: #163
The textBoundingBox function calculates the bounding box of a given text string using an off-screen HTML5 Canvas. It sets the font, measures the text, and extracts bounding metrics (left, right, ascent, descent) to determine the exact dimensions. The function returns a BoundingBox with the computed width, height, and position, along with the TextMetrics object. This is useful for accurate text layout and rendering.