### PR TITLE
Add Gradient Fill Support to Canvas Backend

### DIFF
--- a/canvas/src/main/scala/doodle/canvas/algebra/CanvasDrawing.scala
+++ b/canvas/src/main/scala/doodle/canvas/algebra/CanvasDrawing.scala
@@ -24,6 +24,7 @@ import doodle.algebra.generic.Stroke
 import doodle.core.Cap
 import doodle.core.ClosedPath
 import doodle.core.Color
+import doodle.core.Gradient
 import doodle.core.Join
 import doodle.core.OpenPath
 import doodle.core.PathElement.BezierCurveTo
@@ -128,8 +129,38 @@ object CanvasDrawing {
     CanvasDrawing { ctx =>
       fill match {
         case ColorFill(color) => ctx.fillStyle = colorToCSS(color)
-        // TODO: Implement
-        case GradientFill(gradient) => ()
+        case GradientFill(gradient) =>
+          gradient match {
+            case linear: Gradient.Linear =>
+              val jsGradient = ctx.createLinearGradient(
+                linear.start.x,
+                linear.start.y,
+                linear.end.x,
+                linear.end.y
+              )
+
+              linear.stops.foreach { case (color, offset) =>
+                jsGradient.addColorStop(offset, colorToCSS(color))
+              }
+
+              ctx.fillStyle = jsGradient
+
+            case radial: Gradient.Radial =>
+              val jsGradient = ctx.createRadialGradient(
+                radial.inner.x,
+                radial.inner.y,
+                0, // Inner radius should be 0
+                radial.outer.x,
+                radial.outer.y,
+                radial.radius
+              )
+
+              radial.stops.foreach { case (color, offset) =>
+                jsGradient.addColorStop(offset, colorToCSS(color))
+              }
+
+              ctx.fillStyle = jsGradient
+          }
       }
     }
   }


### PR DESCRIPTION
# Add Gradient Fill Support to Canvas Backend

This PR implements gradient fill support in the Canvas backend, fixing #167.

## Changes Made
- Added import for `doodle.core.Gradient`
- Implemented the `GradientFill` case in the `setFill` method
- Support for both linear and radial gradients using Canvas API's `createLinearGradient()` and `createRadialGradient()`
- Set inner radius to 0 for radial gradients to match expected behavior in other backends

## Testing
- Verified gradient examples render correctly in the Canvas backend
- Tested in multiple browsers (Firefox, Chrome/Brave)
- Both linear and radial gradients display properly
![image](https://github.com/user-attachments/assets/84d64369-21b7-46ff-a263-3a9caabd9d3c)

This implementation preserves the existing code structure and formatting while adding the necessary functionality for gradient fills in Canvas.