### PR TITLE
Bitmap loading foundation

### DIFF
--- a/algebra/js/src/main/scala/doodle/syntax/package.scala
+++ b/algebra/js/src/main/scala/doodle/syntax/package.scala
@@ -28,6 +28,7 @@ package object syntax {
       with DebugSyntax
       with FilterSyntax
       with LayoutSyntax
+      with LoadBitmapSyntax
       with NormalizedSyntax
       with PathSyntax
       with RendererSyntax
@@ -45,6 +46,7 @@ package object syntax {
   object debug extends DebugSyntax
   object filter extends FilterSyntax
   object layout extends LayoutSyntax
+  object loadBitmap extends LoadBitmapSyntax
   object normalized extends NormalizedSyntax
   object path extends PathSyntax
   object renderer extends RendererSyntax

--- a/algebra/jvm/src/main/scala/doodle/syntax/package.scala
+++ b/algebra/jvm/src/main/scala/doodle/syntax/package.scala
@@ -31,6 +31,7 @@ package object syntax {
       with FileWriterSyntax
       with FilterSyntax
       with LayoutSyntax
+      with LoadBitmapSyntax
       with NormalizedSyntax
       with PathSyntax
       with RendererSyntax
@@ -51,6 +52,7 @@ package object syntax {
   object fileWriter extends FileWriterSyntax
   object filter extends FilterSyntax
   object layout extends LayoutSyntax
+  object loadBitmap extends LoadBitmapSyntax
   object normalized extends NormalizedSyntax
   object path extends PathSyntax
   object renderer extends RendererSyntax

--- a/algebra/shared/src/main/scala/doodle/algebra/BitmapError.scala
+++ b/algebra/shared/src/main/scala/doodle/algebra/BitmapError.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package algebra
+
+/** Base type for all bitmap loading errors */
+sealed abstract class BitmapError extends Exception {
+  def message: String
+  override def getMessage: String = message
+}
+
+/** The specified file was not found */
+final case class FileNotFound(path: String) extends BitmapError {
+  val message = s"File not found: $path"
+}
+
+/** The file exists but is not a valid image format */
+final case class InvalidFormat(path: String, cause: Throwable)
+    extends BitmapError {
+  val message = s"Invalid image format: $path"
+  override def getCause: Throwable = cause
+}
+
+/** Network error when loading from URL */
+final case class NetworkError(url: String, cause: Throwable)
+    extends BitmapError {
+  val message = s"Network error loading: $url"
+  override def getCause: Throwable = cause
+}
+
+/** Generic IO error */
+final case class IOError(description: String, cause: Throwable)
+    extends BitmapError {
+  val message = s"IO error: $description"
+  override def getCause: Throwable = cause
+}

--- a/algebra/shared/src/main/scala/doodle/algebra/LoadBitmap.scala
+++ b/algebra/shared/src/main/scala/doodle/algebra/LoadBitmap.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package algebra
+
+import cats.effect.IO
+
+/** Algebra for loading bitmap images from various sources.
+  *
+  * This algebra is parameterized by:
+  * @tparam Specifier
+  *   the type used to specify where to find a bitmap (e.g. File on JVM, String
+  *   URL on JS)
+  * @tparam Bitmap
+  *   the type of the resulting bitmap (e.g. BufferedImage on JVM,
+  *   HTMLImageElement on JS)
+  */
+trait LoadBitmap[Specifier, Bitmap] {
+
+  /** Load a bitmap from the given specifier.
+    *
+    * Returns an IO that either succeeds with the loaded bitmap or fails with a
+    * BitmapError.
+    */
+  def load(specifier: Specifier): IO[Bitmap]
+}
+
+object LoadBitmap {
+
+  /** Summon an instance of LoadBitmap */
+  def apply[S, B](using lb: LoadBitmap[S, B]): LoadBitmap[S, B] = lb
+}

--- a/algebra/shared/src/main/scala/doodle/syntax/LoadBitmapSyntax.scala
+++ b/algebra/shared/src/main/scala/doodle/syntax/LoadBitmapSyntax.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package syntax
+
+import cats.effect.IO
+import doodle.algebra.Algebra
+import doodle.algebra.LoadBitmap
+import doodle.algebra.Picture
+import doodle.algebra.ToPicture
+
+trait LoadBitmapSyntax {
+
+  extension [S, B](specifier: S)(using loader: LoadBitmap[S, B]) {
+
+    /** Load a bitmap from this specifier */
+    def loadBitmap: IO[B] = loader.load(specifier)
+
+    /** Load a bitmap and immediately convert to Picture. This is a convenience
+      * method that combines loading and conversion.
+      */
+    def loadAsPicture[Alg <: Algebra](using
+        tp: ToPicture[B, Alg]
+    ): IO[Picture[Alg, Unit]] =
+      loader.load(specifier).map(tp.toPicture)
+  }
+
+  extension [B](ioBitmap: IO[B]) {
+
+    /** Transform the bitmap inside the IO */
+    def mapBitmap[B2](f: B => B2): IO[B2] = ioBitmap.map(f)
+
+    /** Convert to Picture inside the IO */
+    def toPicture[Alg <: Algebra](using
+        tp: ToPicture[B, Alg]
+    ): IO[Picture[Alg, Unit]] =
+      ioBitmap.map(tp.toPicture)
+  }
+}

--- a/algebra/shared/src/test/scala/doodle/algebra/generic/LoadBitmapSpec.scala
+++ b/algebra/shared/src/test/scala/doodle/algebra/generic/LoadBitmapSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle.algebra.generic
+
+import cats.effect.IO
+import doodle.algebra.*
+import doodle.syntax.loadBitmap.*
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+
+object LoadBitmapSpec extends Properties("LoadBitmap properties") {
+
+  case class TestBitmap(content: String)
+
+  given testLoader: LoadBitmap[String, TestBitmap] with {
+    def load(path: String): IO[TestBitmap] =
+      path match {
+        case s if s.startsWith("missing-") =>
+          IO.raiseError(FileNotFound(path))
+        case s if s.startsWith("corrupt-") =>
+          IO.raiseError(InvalidFormat(path, new Exception("Bad format")))
+        case s if s.startsWith("network-") =>
+          IO.raiseError(NetworkError(path, new Exception("Network error")))
+        case _ =>
+          IO.pure(TestBitmap(s"Content of $path"))
+      }
+  }
+
+  // Test the IO structure
+  property("successful loading returns IO with bitmap") = forAll {
+    (name: String) =>
+      val path = s"valid-$name.png"
+      val result = path.loadBitmap
+
+      result.isInstanceOf[IO[TestBitmap]]
+  }
+
+  property("loadBitmap syntax works") = forAll { (name: String) =>
+    val path = s"test-$name.png"
+    val io = path.loadBitmap
+
+    io.isInstanceOf[IO[TestBitmap]]
+  }
+
+  // Test that errors are properly wrapped in IO
+  property("missing files return failed IO") = {
+    val path = "missing-test.png"
+    val io = path.loadBitmap
+
+    io.isInstanceOf[IO[TestBitmap]]
+  }
+}


### PR DESCRIPTION
Add LoadBitmap algebra for bitmap loading foundation:
- Add LoadBitmap trait for async bitmap loading.
- Define BitmapError hierarchy for type-safe error handling.
- Add LoadBitmapSyntax with IO-based extension methods.
- Add property-based tests for LoadBitmap.

This PR provides only the shared algebra and syntax. Platform-specific implementations and convenience methods will come in backend PRs.

Part of #85