### PR TITLE
Add LoadBitmap algebra implementation for Java2D backend

### DIFF
--- a/java2d/src/main/scala/doodle/java2d/algebra/Java2dLoadBitmap.scala
+++ b/java2d/src/main/scala/doodle/java2d/algebra/Java2dLoadBitmap.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package java2d
+package algebra
+
+import cats.effect.IO
+import doodle.algebra.FileNotFound
+import doodle.algebra.InvalidFormat
+import doodle.algebra.LoadBitmap
+
+import java.awt.image.BufferedImage
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.file.Path
+import javax.imageio.ImageIO
+
+object Java2dLoadBitmap {
+  given LoadBitmap[File, BufferedImage] with {
+    def load(file: File): IO[BufferedImage] =
+      IO {
+        if !file.exists() then {
+          throw new FileNotFoundException(s"File not found: ${file.getPath}")
+        }
+
+        Option(ImageIO.read(file)) match {
+          case Some(image) => image
+          case None        =>
+            throw new IOException(
+              s"Unable to read image from file: ${file.getPath}"
+            )
+        }
+      }.adaptError {
+        case _: FileNotFoundException =>
+          FileNotFound(file.getPath)
+        case e: IOException =>
+          InvalidFormat(file.getPath, e)
+        case e: Exception =>
+          InvalidFormat(file.getPath, e)
+      }
+  }
+
+  given LoadBitmap[Path, BufferedImage] with {
+    def load(path: Path): IO[BufferedImage] =
+      summon[LoadBitmap[File, BufferedImage]].load(path.toFile)
+  }
+}

--- a/java2d/src/main/scala/doodle/java2d/package.scala
+++ b/java2d/src/main/scala/doodle/java2d/package.scala
@@ -29,6 +29,10 @@ import doodle.interact.effect.AnimationWriter
 import doodle.java2d.algebra.reified.Reification
 import doodle.language.Basic
 
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Path
+
 package object java2d extends Java2dToPicture {
   type Algebra =
     doodle.algebra.Algebra
@@ -72,6 +76,11 @@ package object java2d extends Java2dToPicture {
   implicit val java2dBufferedImageWriter
       : BufferedImageWriter[doodle.java2d.Algebra, Frame] =
     doodle.java2d.effect.Java2dBufferedImageWriter
+
+  given LoadBitmap[File, BufferedImage] =
+    doodle.java2d.algebra.Java2dLoadBitmap.loadBitmapFromFile
+  given LoadBitmap[Path, BufferedImage] =
+    doodle.java2d.algebra.Java2dLoadBitmap.loadBitmapFromPath
 
   val Frame = doodle.java2d.effect.Frame
 

--- a/java2d/src/test/scala/doodle/java2d/Java2dLoadBitmapSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/Java2dLoadBitmapSuite.scala
@@ -21,7 +21,7 @@ package algebra
 import cats.effect.unsafe.implicits.global
 import doodle.algebra.FileNotFound
 import doodle.algebra.InvalidFormat
-import doodle.java2d.algebra.Java2dLoadBitmap.given
+import doodle.java2d.{*, given}
 import doodle.syntax.all.*
 import munit.FunSuite
 

--- a/java2d/src/test/scala/doodle/java2d/Java2dLoadBitmapSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/Java2dLoadBitmapSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package java2d
+package algebra
+
+import cats.effect.unsafe.implicits.global
+import doodle.algebra.FileNotFound
+import doodle.algebra.InvalidFormat
+import doodle.java2d.algebra.Java2dLoadBitmap.given
+import doodle.syntax.all.*
+import munit.FunSuite
+
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.imageio.ImageIO
+
+class Java2dLoadBitmapSuite extends FunSuite {
+
+  // Helper to create a test image file
+  def createTestImage(path: Path, width: Int = 100, height: Int = 100): Unit = {
+    val image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    val graphics = image.createGraphics()
+
+    graphics.setColor(java.awt.Color.RED)
+    graphics.fillRect(0, 0, width, height)
+    graphics.dispose()
+
+    val _ = ImageIO.write(image, "png", path.toFile)
+  }
+
+  test("LoadBitmap should successfully load a valid image file") {
+    val tempFile = Files.createTempFile("test", ".png")
+
+    try {
+      createTestImage(tempFile)
+      val result = tempFile.toFile.loadBitmap.unsafeRunSync()
+
+      assertEquals(result.getWidth, 100)
+      assertEquals(result.getHeight, 100)
+    } finally {
+      val _ = Files.deleteIfExists(tempFile)
+    }
+  }
+
+  test("LoadBitmap should return FileNotFound for non-existent file") {
+    val nonExistentFile = new File("this-file-does-not-exist.png")
+
+    val result = nonExistentFile.loadBitmap.attempt.unsafeRunSync()
+
+    assert(result.isLeft)
+    result.left.foreach { error =>
+      assert(error.isInstanceOf[FileNotFound])
+      assertEquals(
+        error.asInstanceOf[FileNotFound].path,
+        nonExistentFile.getPath
+      )
+    }
+  }
+
+  test("LoadBitmap should return InvalidFormat for non-image file") {
+    val tempFile = Files.createTempFile("test", ".txt")
+
+    try {
+      Files.write(tempFile, "This is not an image".getBytes)
+      val result = tempFile.toFile.loadBitmap.attempt.unsafeRunSync()
+
+      assert(result.isLeft)
+      result.left.foreach { error =>
+        assert(error.isInstanceOf[InvalidFormat])
+      }
+    } finally {
+      val _ = Files.deleteIfExists(tempFile)
+    }
+  }
+
+  test("LoadBitmap should work with Path") {
+    val tempPath = Files.createTempFile("test", ".png")
+
+    try {
+      createTestImage(tempPath)
+      val result = tempPath.loadBitmap.unsafeRunSync()
+
+      assertEquals(result.getWidth, 100)
+      assertEquals(result.getHeight, 100)
+    } finally {
+      val _ = Files.deleteIfExists(tempPath)
+    }
+  }
+
+  test("BufferedImage should convert to Picture using existing ToPicture") {
+    val image = new BufferedImage(50, 50, BufferedImage.TYPE_INT_RGB)
+
+    val picture = image.toPicture
+
+    assert(picture != null)
+  }
+
+  test("Complete flow: load image and convert to Picture") {
+    val tempFile = Files.createTempFile("test", ".png")
+
+    try {
+      createTestImage(tempFile, 200, 150)
+
+      val bitmap = tempFile.toFile.loadBitmap.unsafeRunSync()
+      val picture = bitmap.toPicture
+
+      assertEquals(bitmap.getWidth, 200)
+      assertEquals(bitmap.getHeight, 150)
+      assert(picture != null)
+
+      val directPicture =
+        tempFile.toFile.loadAsPicture[doodle.java2d.Algebra].unsafeRunSync()
+      assert(directPicture != null)
+    } finally {
+      val _ = Files.deleteIfExists(tempFile)
+    }
+  }
+}


### PR DESCRIPTION
- Implement LoadBitmap[File, BufferedImage]
- Implement LoadBitmap[Path, BufferedImage]
- Use Option pattern instead of null checks
- Add proper error mapping to typed errors
- Test suite

*Canvas, SVG implementation and convenience methods will be in the next PRs.*