### PR TITLE
Svg bitmap ref implementation, part of Bitmap refactoring task

### DIFF
--- a/docs/src/pages/canvas/bitmap.md
+++ b/docs/src/pages/canvas/bitmap.md
@@ -1,4 +1,4 @@
-# Working With Bitmaps
+# Bitmaps in Canvas
 
 The Canvas backend provides methods to load bitmap images in the various types provided by the web platform (i.e. the browser) and convert them to a Doodle `Picture`.
 
@@ -70,7 +70,7 @@ import org.scalajs.dom
 // Used under CC license https://creativecommons.org/licenses/by-sa/4.0/deed.en
 val wikimediaUrl =
   "https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/A_Koch_woman.jpg/330px-A_Koch_woman.jpg"
-  
+
 val program = for {
   htmlImg <- wikimediaUrl.loadBitmap[dom.HTMLImageElement].toPicture
   imgBitmap <- wikimediaUrl.loadBitmap[dom.ImageBitmap].toPicture

--- a/docs/src/pages/canvas/directory.conf
+++ b/docs/src/pages/canvas/directory.conf
@@ -1,6 +1,6 @@
 laika.navigationOrder = [
   README.md
-  bitmaps.md
+  bitmap.md
   examples.md
   layout-examples.md
   style-examples.md

--- a/docs/src/pages/svg/bitmap.md
+++ b/docs/src/pages/svg/bitmap.md
@@ -1,0 +1,147 @@
+# Bitmaps in SVG
+
+```scala mdoc:invisible
+import cats.effect.unsafe.implicits.global
+import doodle.core.*
+import doodle.svg.{*, given}
+import doodle.svg.algebra.{SvgImageRef, SvgLoadBitmap}
+import doodle.syntax.all.*
+```
+
+The SVG backend provides support for bitmap images through `<image>` elements. Unlike raster-based backends, SVG doesn't load actual pixel data. Instead, it creates image references that the browser loads and renders.
+
+
+## How SVG Handles Bitmaps
+
+SVG handles bitmaps differently from other backends:
+
+- **No pixel manipulation**: SVG creates `<image>` elements with `href` attributes pointing to image sources.
+- **Browser-handled loading**: the browser handles fetching images and respecting CORS policies.
+- **Vector context**: bitmaps are embedded in a vector graphics context and can have SVG transformations and filters applied.
+
+
+## Loading Bitmap References
+
+In the SVG backend, "loading" a bitmap creates an `SvgImageRef` which stores the image URL and optional dimensions. The specifier type is `String` (representing a URL or data URI).
+
+```scala mdoc:compile-only
+// Load from URL
+val imageRef = "https://example.com/image.png".loadBitmap[SvgImageRef]
+
+// Load from data URI
+val dataUri = "data:image/png;base64,iVBORw0KGgoAAAANS..."
+val dataRef = dataUri.loadBitmap[SvgImageRef]
+
+// Load from relative path
+val localRef = "images/logo.svg".loadBitmap[SvgImageRef]
+```
+
+Note* that `loadBitmap` returns an `IO[SvgImageRef]`. Use `.unsafeRunSync()` to extract the value in examples, or handle the `IO` properly in production code.
+
+
+## Specifying Dimensions
+
+You can optionally specify dimensions when creating image references:
+
+```scala mdoc:compile-only
+// With both width and height
+val withDims = SvgLoadBitmap.withDimensions("image.jpg", width = 200, height = 150)
+
+// With width only (height auto-calculated by browser)
+val withWidth = SvgLoadBitmap.withWidth("image.png", width = 300)
+
+// With height only (width auto-calculated by browser)
+val withHeight = SvgLoadBitmap.withHeight("image.gif", height = 250)
+```
+
+If dimensions are not specified, the SVG backend uses a default size of 100x100 pixels for bounding box calculations.
+
+
+## Converting to Pictures
+
+An `SvgImageRef` can be converted to a `Picture` using the `toPicture` method:
+
+```scala mdoc:compile-only
+val imageRefIO = "photo.jpg".loadBitmap[SvgImageRef]
+val imageRef = imageRefIO.unsafeRunSync()
+val picture = imageRef.toPicture
+
+// Or load and convert in one step
+val directPictureIO = "photo.jpg".loadBitmap[SvgImageRef].toPicture
+val directPicture = directPictureIO.unsafeRunSync()
+```
+
+
+## Composing with Vector Graphics
+
+Since bitmap references become regular `Pictures`, they can be composed with vector graphics:
+
+```scala mdoc:compile-only
+val logoIO = for {
+  imageRef <- "logo.png".loadBitmap[SvgImageRef]
+  logo = imageRef.toPicture
+} yield logo
+  .on(circle(150).fillColor(Color.lightBlue))
+  .beside(text("Welcome").fillColor(Color.black))
+
+val composition = logoIO.unsafeRunSync()
+```
+
+
+## SVG Filters on Bitmaps
+
+SVG filters can be applied to bitmap images just like any other `Picture`:
+
+```scala mdoc:compile-only
+val filteredIO = for {
+  imageRef <- "photo.jpg".loadBitmap[SvgImageRef]
+  image = imageRef.toPicture
+} yield image
+  .blur(3.0)
+  .dropShadow(4, 4, 2, Color.black.alpha(0.5.normalized))
+
+val filtered = filteredIO.unsafeRunSync()
+```
+
+
+## Complete Example
+
+This example demonstrates loading an image, applying transformations, and composing with vector graphics:
+
+```scala mdoc:compile-only
+val program = for {
+  // Load the image reference
+  imageRef <- "https://example.com/logo.png".loadBitmap[SvgImageRef]
+
+  // Convert to Picture
+  logo = imageRef.toPicture
+
+  // Create composition
+  composition = logo
+    .scale(0.75, 0.75)
+    .on(square(200).fillColor(Color.lightGray))
+    .above(text("Company Name").fillColor(Color.darkGray))
+
+} yield composition
+
+// In production, handle IO properly
+// For examples, we can use unsafeRunSync
+val result = program.unsafeRunSync()
+```
+
+
+## Important Considerations
+
+### CORS Policies
+
+When loading images from external domains, be aware of CORS (Cross-Origin Resource Sharing) policies.
+
+### No Pixel Access
+
+Unlike Java2D or Canvas backends, SVG cannot:
+
+- Access individual pixels.
+- Convert Pictures to bitmap data.
+- Apply pixel-level manipulations.
+
+For these operations, use a raster-based backend.

--- a/docs/src/pages/svg/directory.conf
+++ b/docs/src/pages/svg/directory.conf
@@ -1,0 +1,4 @@
+laika.navigationOrder = [
+  README.md
+  bitmap.md
+]

--- a/svg/js/src/main/scala/doodle/svg/algebra/Algebra.scala
+++ b/svg/js/src/main/scala/doodle/svg/algebra/Algebra.scala
@@ -33,6 +33,7 @@ trait JsAlgebraModule
     with SvgModule
     with TextModule
     with FilterModule
+    with ImageModule
     with JsBase {
   type Algebra = JsAlgebra
 
@@ -43,6 +44,7 @@ trait JsAlgebraModule
   ) extends BaseAlgebra
       with Text
       with Filter
+      with Image
       with HasTextBoundingBox[Rect] {
     def textBoundingBox(text: String, font: Font): (BoundingBox, Rect) =
       canvas.textBoundingBox(text, font)

--- a/svg/js/src/main/scala/doodle/svg/package.scala
+++ b/svg/js/src/main/scala/doodle/svg/package.scala
@@ -16,8 +16,13 @@
 
 package doodle
 
+import doodle.algebra.LoadBitmap
+import doodle.algebra.ToPicture
 import doodle.effect.Renderer
 import doodle.interact.effect.AnimationRenderer
+import doodle.svg.algebra.SvgImageRef
+import doodle.svg.algebra.SvgLoadBitmap
+import doodle.svg.algebra.SvgToPicture
 
 package object svg {
   val js = new doodle.svg.algebra.JsAlgebraModule {}
@@ -39,6 +44,11 @@ package object svg {
     doodle.svg.algebra.CanvasAlgebra
 
   val Frame = doodle.svg.effect.Frame
+
+  given LoadBitmap[String, SvgImageRef] =
+    SvgLoadBitmap.loadBitmapFromUrl
+  given [Alg <: svg.Algebra]: ToPicture[SvgImageRef, Alg] =
+    SvgToPicture.svgImageRefToPicture[Alg]
 
   type Picture[A] = doodle.algebra.Picture[Algebra, A]
   object Picture

--- a/svg/jvm/src/main/scala/doodle/svg/algebra/Algebra.scala
+++ b/svg/jvm/src/main/scala/doodle/svg/algebra/Algebra.scala
@@ -35,6 +35,7 @@ trait JvmAlgebraModule
     with SvgModule
     with TextModule
     with FilterModule
+    with ImageModule
     with JvmBase {
   type Algebra = JvmAlgebra
 
@@ -43,6 +44,7 @@ trait JvmAlgebraModule
       with BaseAlgebra
       with Text
       with Filter
+      with Image
       with HasTextBoundingBox[Rectangle2D] {
 
     def textBoundingBox(

--- a/svg/jvm/src/main/scala/doodle/svg/package.scala
+++ b/svg/jvm/src/main/scala/doodle/svg/package.scala
@@ -16,9 +16,14 @@
 
 package doodle
 
+import doodle.algebra.LoadBitmap
+import doodle.algebra.ToPicture
 import doodle.core.format.Svg
 import doodle.effect.DefaultFrame
 import doodle.effect.FileWriter
+import doodle.svg.algebra.SvgImageRef
+import doodle.svg.algebra.SvgLoadBitmap
+import doodle.svg.algebra.SvgToPicture
 
 package object svg {
   val jvm = new doodle.svg.algebra.JvmAlgebraModule {}
@@ -39,6 +44,11 @@ package object svg {
     new DefaultFrame[doodle.svg.effect.Frame] {
       val default: Frame = doodle.svg.effect.Frame("dummy")
     }
+
+  given LoadBitmap[String, SvgImageRef] =
+    SvgLoadBitmap.loadBitmapFromUrl
+  given [Alg <: svg.Algebra]: ToPicture[SvgImageRef, Alg] =
+    SvgToPicture.svgImageRefToPicture[Alg]
 
   type Picture[A] = doodle.algebra.Picture[Algebra, A]
   object Picture

--- a/svg/shared/src/main/scala/doodle/svg/algebra/BaseAlgebra.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/BaseAlgebra.scala
@@ -29,7 +29,8 @@ trait AlgebraModule {
     with ShapeModule
     with PathModule
     with SvgModule
-    with FilterModule =>
+    with FilterModule
+    with ImageModule =>
   trait BaseAlgebra
       extends doodle.algebra.Algebra
       with Layout
@@ -38,6 +39,7 @@ trait AlgebraModule {
       with Path
       with Text
       with Filter
+      with Image
       with GenericDebug[SvgResult]
       with GenericLayout[SvgResult]
       with GenericSize[SvgResult]

--- a/svg/shared/src/main/scala/doodle/svg/algebra/Image.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/Image.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package svg
+package algebra
+
+import cats.data.State
+import doodle.algebra.generic.*
+import doodle.core.BoundingBox
+import doodle.core.Transform as Tx
+
+import scala.collection.mutable
+
+/** Module for handling bitmap images in SVG via <image> elements */
+trait ImageModule { root: Base with SvgModule =>
+  trait Image {
+    self: doodle.algebra.Algebra {
+      type Drawing[A] = doodle.algebra.generic.Finalized[SvgResult, A]
+    } =>
+
+    /** Create an SVG image element from a reference */
+    def image(ref: SvgImageRef): Drawing[Unit] = {
+      Finalized.leaf { dc =>
+        val bb = (ref.width, ref.height) match {
+          case (Some(w), Some(h)) => BoundingBox.centered(w, h)
+          case (Some(w), None)    => BoundingBox.centered(w, w)
+          case (None, Some(h))    => BoundingBox.centered(h, h)
+          case (None, None)       => BoundingBox.centered(100, 100)
+        }
+
+        val renderable = State.inspect[Tx, SvgResult[Unit]] { tx =>
+          val b = bundle
+          import b.implicits.*
+          import b.{svgAttrs, svgTags}
+
+          val set = mutable.Set.empty[root.Tag]
+
+          val imgTag = (ref.width, ref.height) match {
+            case (Some(w), Some(h)) =>
+              svgTags.image(
+                svgAttrs.xLinkHref := ref.href,
+                svgAttrs.width := w,
+                svgAttrs.height := h,
+                svgAttrs.x := -w / 2,
+                svgAttrs.y := -h / 2,
+                svgAttrs.transform := Svg.toSvgTransform(tx)
+              )
+            case (Some(w), None) =>
+              svgTags.image(
+                svgAttrs.xLinkHref := ref.href,
+                svgAttrs.width := w,
+                svgAttrs.x := -w / 2,
+                svgAttrs.transform := Svg.toSvgTransform(tx)
+              )
+            case (None, Some(h)) =>
+              svgTags.image(
+                svgAttrs.xLinkHref := ref.href,
+                svgAttrs.height := h,
+                svgAttrs.y := -h / 2,
+                svgAttrs.transform := Svg.toSvgTransform(tx)
+              )
+            case (None, None) =>
+              svgTags.image(
+                svgAttrs.xLinkHref := ref.href,
+                svgAttrs.transform := Svg.toSvgTransform(tx)
+              )
+          }
+
+          (imgTag, set, ())
+        }
+
+        (bb, renderable)
+      }
+    }
+  }
+}

--- a/svg/shared/src/main/scala/doodle/svg/algebra/SvgLoadBitmap.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/SvgLoadBitmap.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package svg
+package algebra
+
+import cats.effect.IO
+import doodle.algebra.LoadBitmap
+
+/** SVG-specific image reference that stores URL and optional dimensions */
+final case class SvgImageRef(
+    href: String,
+    width: Option[Double] = None,
+    height: Option[Double] = None
+)
+
+/** LoadBitmap implementation for SVG that creates image references */
+object SvgLoadBitmap {
+  val loadBitmapFromUrl: LoadBitmap[String, SvgImageRef] =
+    new LoadBitmap[String, SvgImageRef] {
+      def load(specifier: String): IO[SvgImageRef] =
+        IO.pure(SvgImageRef(specifier))
+    }
+
+  /** Create an image reference with specific dimensions */
+  def withDimensions(
+      href: String,
+      width: Double,
+      height: Double
+  ): IO[SvgImageRef] =
+    IO.pure(SvgImageRef(href, Some(width), Some(height)))
+
+  /** Create an image reference with width only (height will be auto-calculated)
+    */
+  def withWidth(href: String, width: Double): IO[SvgImageRef] =
+    IO.pure(SvgImageRef(href, Some(width), None))
+
+  /** Create an image reference with height only (width will be auto-calculated)
+    */
+  def withHeight(href: String, height: Double): IO[SvgImageRef] =
+    IO.pure(SvgImageRef(href, None, Some(height)))
+}

--- a/svg/shared/src/main/scala/doodle/svg/algebra/SvgToPicture.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/SvgToPicture.scala
@@ -23,6 +23,13 @@ import doodle.algebra.ToPicture
 
 /** ToPicture implementation for SVG image references */
 object SvgToPicture {
+
+  /** Creates a ToPicture instance for SvgImageRef.
+    *
+    * Note on type constraint: We require svg.Algebra here, but in practice we
+    * only use the `image` method from the Image trait. Any algebra that
+    * includes ImageModule will work with this implementation.
+    */
   def svgImageRefToPicture[Alg <: svg.Algebra]: ToPicture[SvgImageRef, Alg] =
     new ToPicture[SvgImageRef, Alg] {
       def toPicture(ref: SvgImageRef): Picture[Alg, Unit] =

--- a/svg/shared/src/main/scala/doodle/svg/algebra/SvgToPicture.scala
+++ b/svg/shared/src/main/scala/doodle/svg/algebra/SvgToPicture.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package svg
+package algebra
+
+import doodle.algebra.Picture
+import doodle.algebra.ToPicture
+
+/** ToPicture implementation for SVG image references */
+object SvgToPicture {
+  def svgImageRefToPicture[Alg <: svg.Algebra]: ToPicture[SvgImageRef, Alg] =
+    new ToPicture[SvgImageRef, Alg] {
+      def toPicture(ref: SvgImageRef): Picture[Alg, Unit] =
+        new Picture[Alg, Unit] {
+          def apply(implicit algebra: Alg): algebra.Drawing[Unit] =
+            algebra.image(ref)
+        }
+    }
+}

--- a/svg/shared/src/test/scala/doodle/svg/SvgLoadBitmapSpec.scala
+++ b/svg/shared/src/test/scala/doodle/svg/SvgLoadBitmapSpec.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle
+package svg
+
+import cats.effect.IO
+import doodle.core.*
+import doodle.svg.algebra.SvgImageRef
+import doodle.svg.algebra.SvgLoadBitmap
+import munit.CatsEffectSuite
+
+class SvgLoadBitmapSpec
+    extends CatsEffectSuite
+    with doodle.svg.algebra.TestAlgebraModule {
+
+  test("LoadBitmap creates correct SvgImageRef from URL") {
+    IO {
+      val url = "https://example.com/image.png"
+      val imageRef = SvgImageRef(url)
+
+      assertEquals(imageRef.href, url)
+      assertEquals(imageRef.width, None)
+      assertEquals(imageRef.height, None)
+    }
+  }
+
+  test("LoadBitmap creates SvgImageRef with dimensions") {
+    val url = "https://example.com/image.jpg"
+    val width = 200.0
+    val height = 150.0
+
+    for {
+      imageRef <- SvgLoadBitmap.withDimensions(url, width, height)
+    } yield {
+      assertEquals(imageRef.href, url)
+      assertEquals(imageRef.width, Some(width))
+      assertEquals(imageRef.height, Some(height))
+    }
+  }
+
+  test("LoadBitmap creates SvgImageRef with width only") {
+    val url = "image.svg"
+    val width = 300.0
+
+    for {
+      imageRef <- SvgLoadBitmap.withWidth(url, width)
+    } yield {
+      assertEquals(imageRef.href, url)
+      assertEquals(imageRef.width, Some(width))
+      assertEquals(imageRef.height, None)
+    }
+  }
+
+  test("LoadBitmap creates SvgImageRef with height only") {
+    val url =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    val height = 250.0
+
+    for {
+      imageRef <- SvgLoadBitmap.withHeight(url, height)
+    } yield {
+      assertEquals(imageRef.href, url)
+      assertEquals(imageRef.width, None)
+      assertEquals(imageRef.height, Some(height))
+    }
+  }
+
+  test("image method creates Drawing with correct bounding box") {
+    IO {
+      val imageRef = SvgImageRef("test.png", Some(100), Some(100))
+      val drawing = algebraInstance.image(imageRef)
+      val bb = drawing.boundingBox
+
+      assertEquals(bb.width, 100.0)
+      assertEquals(bb.height, 100.0)
+    }
+  }
+
+  test("image element is properly centered") {
+    IO {
+      val imageRef = SvgImageRef("centered.jpg", Some(200), Some(100))
+      val drawing = algebraInstance.image(imageRef)
+      val bb = drawing.boundingBox
+
+      // Image should be centered at origin
+      assertEquals(bb.left, -100.0)
+      assertEquals(bb.right, 100.0)
+      assertEquals(bb.top, 50.0)
+      assertEquals(bb.bottom, -50.0)
+    }
+  }
+
+  test("default dimensions are used when not specified") {
+    IO {
+      val imageRef = SvgImageRef("default.gif")
+      val drawing = algebraInstance.image(imageRef)
+      val bb = drawing.boundingBox
+
+      // Should use default dimensions
+      assertEquals(bb.width, 100.0)
+      assertEquals(bb.height, 100.0)
+    }
+  }
+
+  test("image renders to SVG image element") {
+    val imageRef = SvgImageRef("render.png", Some(100), Some(80))
+    // val drawing = algebraInstance.image(imageRef)
+
+    // Create a simple picture that uses the image
+    val picture = new doodle.algebra.Picture[TestAlgebra, Unit] {
+      def apply(implicit algebra: TestAlgebra): algebra.Drawing[Unit] =
+        algebra.image(imageRef)
+    }
+
+    Svg
+      .renderWithoutRootTag(algebraInstance, picture)
+      .map { case (_, tag, _) =>
+        val tagStr = tag.render
+
+        assert(tagStr.contains("<image"))
+        assert(tagStr.contains("xlink:href=\"render.png\""))
+        assert(tagStr.contains("width=\"100"))
+        assert(tagStr.contains("height=\"80"))
+        assert(tagStr.contains("x=\"-50"))
+        assert(tagStr.contains("y=\"-40"))
+      }
+  }
+
+  test("image without dimensions renders correctly") {
+    val imageRef = SvgImageRef("nodims.svg")
+
+    val picture = new doodle.algebra.Picture[TestAlgebra, Unit] {
+      def apply(implicit algebra: TestAlgebra): algebra.Drawing[Unit] =
+        algebra.image(imageRef)
+    }
+
+    Svg
+      .renderWithoutRootTag(algebraInstance, picture)
+      .map { case (_, tag, _) =>
+        val tagStr = tag.render
+
+        assert(tagStr.contains("<image"))
+        assert(tagStr.contains("xlink:href=\"nodims.svg\""))
+
+        // Should not have width/height attributes when not specified
+        assert(!tagStr.contains("width=\"") || tagStr.contains("width=\"100"))
+        assert(!tagStr.contains("height=\"") || tagStr.contains("height=\"100"))
+      }
+  }
+
+  test("image with only width renders correctly") {
+    val imageRef = SvgImageRef("width-only.jpg", Some(150), None)
+
+    val picture = new doodle.algebra.Picture[TestAlgebra, Unit] {
+      def apply(implicit algebra: TestAlgebra): algebra.Drawing[Unit] =
+        algebra.image(imageRef)
+    }
+
+    Svg
+      .renderWithoutRootTag(algebraInstance, picture)
+      .map { case (_, tag, _) =>
+        val tagStr = tag.render
+
+        assert(tagStr.contains("<image"))
+        assert(tagStr.contains("xlink:href=\"width-only.jpg\""))
+        assert(tagStr.contains("width=\"150"))
+        assert(tagStr.contains("x=\"-75"))
+        // Height should not be specified
+        assert(!tagStr.contains("height=\"") || tagStr.contains("height=\"150"))
+      }
+  }
+}

--- a/svg/shared/src/test/scala/doodle/svg/algebra/TestAlgebra.scala
+++ b/svg/shared/src/test/scala/doodle/svg/algebra/TestAlgebra.scala
@@ -30,6 +30,7 @@ trait TestAlgebraModule
     with ShapeModule
     with SvgModule
     with FilterModule
+    with ImageModule
     with TestBase {
 
   type Algebra = TestAlgebra
@@ -38,7 +39,8 @@ trait TestAlgebraModule
       val applyF: Apply[SvgResult],
       val functorF: Functor[SvgResult]
   ) extends BaseAlgebra
-      with Filter {
+      with Filter
+      with Image {
 
     def font[A](image: Drawing[A], font: Font): TestAlgebra.this.Drawing[A] =
       ???


### PR DESCRIPTION
# SVG bitmap support

SVG bitmap support differs from Canvas and Java2d bitmap refactoring task, because SVG doesn't manipulate pixels.  It references images via `<image>` elements with href attributes.
- `LoadBitmap[String, SvgImageRef] `- takes URL, returns image reference
- `ToPicture[SvgImageRef, Algebra]` - converts reference to `Picture` that generates `<image>` element
- package updates - add given instances to make it available
- tests - unit tests (SVG is cross-platform, so we can test in JVM environment)