### PR TITLE
Add Load Bitmap Convenience backend-specific methods, part of Bitmap refactoring task

### DIFF
--- a/algebra/js/src/main/scala/doodle/syntax/LoadBitmapConvenienceSyntax.scala
+++ b/algebra/js/src/main/scala/doodle/syntax/LoadBitmapConvenienceSyntax.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle.syntax
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import doodle.algebra.BitmapError
+import doodle.algebra.LoadBitmap
+
+import scala.concurrent.Future
+
+trait LoadBitmapConvenienceSyntax {
+
+  /** Extension methods for the LoadBitmap companion object */
+  extension (companion: LoadBitmap.type) {
+
+    /** Load a bitmap asynchronously.
+      *
+      * @param specifier
+      *   the URL of the bitmap
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   Future containing the loaded bitmap or failure
+      */
+    def loadUnsafeAsync[S, B](specifier: S)(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): Future[B] = {
+      loader.load(specifier).unsafeToFuture()
+    }
+
+    /** Load a bitmap asynchronously, returning a default value on any error.
+      *
+      * @param specifier
+      *   the URL of the bitmap
+      * @param default
+      *   the bitmap to return if loading fails
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   Future containing the loaded bitmap or the default
+      */
+    def loadOrDefaultAsync[S, B](specifier: S, default: => B)(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): Future[B] = {
+      loader
+        .load(specifier)
+        .attempt
+        .unsafeToFuture()
+        .map {
+          case Left(_)       => default
+          case Right(bitmap) => bitmap
+        }(scala.concurrent.ExecutionContext.global)
+    }
+
+    /** Load a bitmap asynchronously with partial error recovery.
+      *
+      * @param specifier
+      *   the URL of the bitmap
+      * @param recover
+      *   partial function to handle specific BitmapError cases
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   Future containing the loaded bitmap or recovery result
+      */
+    def loadOrRecoverAsync[S, B](specifier: S)(
+        recover: PartialFunction[BitmapError, B]
+    )(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): Future[B] = {
+      loader
+        .load(specifier)
+        .handleErrorWith { error =>
+          error match {
+            case be: BitmapError if recover.isDefinedAt(be) =>
+              IO.pure(recover(be))
+            case other =>
+              IO.raiseError(other)
+          }
+        }
+        .unsafeToFuture()
+    }
+  }
+}

--- a/algebra/js/src/main/scala/doodle/syntax/package.scala
+++ b/algebra/js/src/main/scala/doodle/syntax/package.scala
@@ -29,6 +29,7 @@ package object syntax {
       with FilterSyntax
       with LayoutSyntax
       with LoadBitmapSyntax
+      with LoadBitmapConvenienceSyntax
       with NormalizedSyntax
       with PathSyntax
       with RendererSyntax
@@ -47,6 +48,7 @@ package object syntax {
   object filter extends FilterSyntax
   object layout extends LayoutSyntax
   object loadBitmap extends LoadBitmapSyntax
+  object loadBitmapConvenience extends LoadBitmapConvenienceSyntax
   object normalized extends NormalizedSyntax
   object path extends PathSyntax
   object renderer extends RendererSyntax

--- a/algebra/jvm/src/main/scala/doodle/syntax/LoadBitmapConvenienceSyntax.scala
+++ b/algebra/jvm/src/main/scala/doodle/syntax/LoadBitmapConvenienceSyntax.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle.syntax
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import doodle.algebra.BitmapError
+import doodle.algebra.LoadBitmap
+
+trait LoadBitmapConvenienceSyntax {
+
+  /** Extension methods for the LoadBitmap companion object */
+  extension (companion: LoadBitmap.type) {
+
+    /** Load a bitmap synchronously, throwing any errors that occur.
+      *
+      * @param specifier
+      *   the location/identifier of the bitmap
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   the loaded bitmap
+      * @throws BitmapError
+      *   if loading fails
+      */
+    def loadUnsafe[S, B](specifier: S)(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): B = {
+      loader.load(specifier).unsafeRunSync()(runtime)
+    }
+
+    /** Load a bitmap synchronously, returning a default value on any error.
+      *
+      * @param specifier
+      *   the location/identifier of the bitmap
+      * @param default
+      *   the bitmap to return if loading fails (evaluated lazily)
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   the loaded bitmap or the default
+      */
+    def loadOrDefault[S, B](specifier: S, default: => B)(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): B = {
+      loader.load(specifier).attempt.unsafeRunSync()(runtime) match {
+        case Left(_)       => default
+        case Right(bitmap) => bitmap
+      }
+    }
+
+    /** Load a bitmap synchronously with partial error recovery.
+      *
+      * @param specifier
+      *   the location/identifier of the bitmap
+      * @param recover
+      *   partial function to handle specific BitmapError cases
+      * @param loader
+      *   implicit LoadBitmap instance for the types
+      * @param runtime
+      *   explicit IORuntime for executing the IO
+      * @return
+      *   the loaded bitmap or recovery result
+      * @throws Throwable
+      *   if the error is not handled by recover
+      */
+    def loadOrRecover[S, B](specifier: S)(
+        recover: PartialFunction[BitmapError, B]
+    )(using
+        loader: LoadBitmap[S, B],
+        runtime: IORuntime
+    ): B = {
+      loader
+        .load(specifier)
+        .handleErrorWith { error =>
+          error match {
+            case be: BitmapError if recover.isDefinedAt(be) =>
+              IO.pure(recover(be))
+            case other =>
+              IO.raiseError(other)
+          }
+        }
+        .unsafeRunSync()(runtime)
+    }
+  }
+}

--- a/algebra/jvm/src/main/scala/doodle/syntax/package.scala
+++ b/algebra/jvm/src/main/scala/doodle/syntax/package.scala
@@ -32,6 +32,7 @@ package object syntax {
       with FilterSyntax
       with LayoutSyntax
       with LoadBitmapSyntax
+      with LoadBitmapConvenienceSyntax
       with NormalizedSyntax
       with PathSyntax
       with RendererSyntax
@@ -53,6 +54,7 @@ package object syntax {
   object filter extends FilterSyntax
   object layout extends LayoutSyntax
   object loadBitmap extends LoadBitmapSyntax
+  object loadBitmapConvenience extends LoadBitmapConvenienceSyntax
   object normalized extends NormalizedSyntax
   object path extends PathSyntax
   object renderer extends RendererSyntax

--- a/algebra/shared/src/main/scala/doodle/algebra/LoadBitmapConvenience.scala
+++ b/algebra/shared/src/main/scala/doodle/algebra/LoadBitmapConvenience.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doodle.algebra
+
+/** Convenience methods for LoadBitmap that provide synchronous, unsafe
+  * operations.
+  *
+  * These are convenience methods for cases where:
+  *   - You don't want to deal with IO ceremony
+  *   - You're in a context where throwing exceptions is acceptable
+  *   - You need simple fallback behavior for errors
+  *
+  * Note: The actual implementation is platform-specific due to differences in
+  * how IO is executed synchronously or asynchronously on JVM vs JS.
+  */
+trait LoadBitmapConvenience {
+
+  /** Load a bitmap synchronously, throwing any errors that occur.
+    *
+    * This is the simplest but most dangerous way to load a bitmap. Use when
+    * you're certain the bitmap exists and is valid.
+    *
+    * @param specifier
+    *   the location/identifier of the bitmap
+    * @param loader
+    *   implicit LoadBitmap instance for the types
+    * @return
+    *   the loaded bitmap
+    * @throws BitmapError
+    *   if loading fails
+    */
+  def loadUnsafe[S, B](specifier: S)(using loader: LoadBitmap[S, B]): B
+
+  /** Load a bitmap synchronously, returning a default value on any error.
+    *
+    * This is safer than loadUnsafe as it won't throw exceptions. Useful when
+    * you have a reasonable fallback image.
+    *
+    * @param specifier
+    *   the location/identifier of the bitmap
+    * @param default
+    *   the bitmap to return if loading fails (evaluated lazily)
+    * @param loader
+    *   implicit LoadBitmap instance for the types
+    * @return
+    *   the loaded bitmap or the default
+    */
+  def loadOrDefault[S, B](specifier: S, default: => B)(using
+      loader: LoadBitmap[S, B]
+  ): B
+
+  /** Load a bitmap synchronously with partial error recovery.
+    *
+    * Allows handling specific error cases while letting others propagate.
+    * Useful when different errors require different fallback strategies.
+    *
+    * @param specifier
+    *   the location/identifier of the bitmap
+    * @param recover
+    *   partial function to handle specific BitmapError cases
+    * @param loader
+    *   implicit LoadBitmap instance for the types
+    * @return
+    *   the loaded bitmap or recovery result
+    * @throws Throwable
+    *   if the error is not handled by recover
+    */
+  def loadOrRecover[S, B](specifier: S)(
+      recover: PartialFunction[BitmapError, B]
+  )(using loader: LoadBitmap[S, B]): B
+}


### PR DESCRIPTION
# Backend specific convenience methods
- loadUnsafe
- loadOrDefault
- loadOrRecover

## JVM backend
Has `unsafeRunSync()` - can block the thread and wait for result.

## JS backend
Only has `unsafeRunAsync()` and/ `unsafeToFuture()` - js is single-threaded and cannot block, event loop based.

##  Shared
LoadBitmapConvenience shared trait - can be removed, cannot be shared across backends. Preserved only as documentation of the interface.

Lives without companion object.

---

## JS backend implementations notes

We have 3 options there, as far as I can see:
- without convenience methods at all
- with `Async` convenience methods
- with error-throwing methods

### JS with async convenience methods | currently chosen
- Provides `loadUnsafeAsync`, `loadOrDefaultAsync`, etc.
- Returns `Future[B]` instead of `B`
- Different API but similar convenience

### Error-throwing methods
- Throws informative errors explaining why it can't work
- Maybe guides users to the correct IO-based API

Something like
```
LoadBitmap.loadUnsafe is not supported in JavaScript/Canvas. 
JavaScript cannot synchronously block on async operations. 
Please use the IO-based API instead: specifier.loadBitmap[B].flatMap { ... }
```

but mostly it will be:
```
Not supported in JavaScript - throws UnsupportedOperationException
...
Not supported in JavaScript - throws UnsupportedOperationException
...
```