### PR TITLE
Add Java2D bitmap filter support with convolution operations

### DIFF
--- a/java2d/src/main/scala/doodle/java2d/algebra/Algebra.scala
+++ b/java2d/src/main/scala/doodle/java2d/algebra/Algebra.scala
@@ -33,6 +33,7 @@ final case class Algebra(
     applyDrawing: Apply[Reification] = Apply.apply[Reification],
     functorDrawing: Functor[Reification] = Apply.apply[Reification]
 ) extends Basic
+    with FilterModule
     with Java2dFromBufferedImage
     with Java2dFromBase64
     with ReifiedBitmap

--- a/java2d/src/main/scala/doodle/java2d/algebra/Filter.scala
+++ b/java2d/src/main/scala/doodle/java2d/algebra/Filter.scala
@@ -1,0 +1,289 @@
+package doodle
+package java2d
+package algebra
+
+import cats.Eval
+import cats.data.WriterT
+import doodle.algebra.{Filter as FilterAlgebra, Kernel}
+import doodle.algebra.generic.*
+import doodle.core.{BoundingBox, Color, Transform as Tx}
+import doodle.java2d.algebra.reified.*
+import doodle.java2d.effect.Java2d
+import java.awt.image.{BufferedImage, ConvolveOp, Kernel as AwtKernel}
+import java.awt.{Graphics2D, RenderingHints, AlphaComposite}
+
+/** Java2D implementation of the Filter algebra using BufferedImage operations
+  */
+trait FilterModule extends FilterAlgebra {
+  self: Algebra =>
+
+  def gaussianBlur[A](picture: Drawing[A], stdDeviation: Double): Drawing[A] =
+    transformToBufferedImage(picture)(applyGaussianBlur(_, stdDeviation))
+
+  def boxBlur[A](picture: Drawing[A], radius: Int): Drawing[A] = {
+    val size = 2 * radius + 1
+    val kernel =
+      Kernel(size, size, IArray.fill(size * size)(1.0 / (size * size)))
+    convolveMatrix(picture, kernel, Some(1.0), 0.0)
+  }
+
+  def detectEdges[A](picture: Drawing[A]): Drawing[A] =
+    convolveMatrix(picture, FilterAlgebra.edgeDetectionKernel, Some(1.0), 0.5)
+
+  def sharpen[A](picture: Drawing[A], amount: Double): Drawing[A] = {
+    val baseKernel = FilterAlgebra.sharpenKernel
+    val scaledElements = IArray.tabulate(baseKernel.elements.length)(i =>
+      baseKernel.elements(i) * amount
+    )
+    val kernel = baseKernel.copy(elements = scaledElements)
+    convolveMatrix(picture, kernel, None, 0.0)
+  }
+
+  def emboss[A](picture: Drawing[A]): Drawing[A] =
+    convolveMatrix(picture, FilterAlgebra.embossKernel, None, 0.0)
+
+  def dropShadow[A](
+      picture: Drawing[A],
+      offsetX: Double,
+      offsetY: Double,
+      blur: Double,
+      color: Color
+  ): Drawing[A] = {
+    // Note: Java2D drop shadow is complex and requires multiple operations
+    // This is a simplified implementation - full implementation would need:
+    // 1. Extract alpha channel as shadow
+    // 2. Apply blur to shadow
+    // 3. Offset shadow
+    // 4. Colorize shadow
+    // 5. Composite original over shadow
+    // For now, we'll implement a basic version
+    transformToBufferedImage(picture) { image =>
+      applyDropShadow(image, offsetX.toInt, offsetY.toInt, blur, color)
+    }
+  }
+
+  def convolveMatrix[A](
+      picture: Drawing[A],
+      kernel: Kernel,
+      divisor: Option[Double],
+      bias: Double
+  ): Drawing[A] =
+    transformToBufferedImage(picture) { image =>
+      applyConvolution(image, kernel, divisor, bias)
+    }
+
+  private def transformToBufferedImage[A](
+      picture: Drawing[A]
+  )(transform: BufferedImage => BufferedImage): Drawing[A] =
+    picture.flatMap { case (bb, rdr) =>
+      Finalized.leaf { dc =>
+        val width = Math.max(1, Math.ceil(bb.width).toInt)
+        val height = Math.max(1, Math.ceil(bb.height).toInt)
+
+        val image =
+          new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val g2d = image.createGraphics()
+        setupGraphics(g2d)
+
+        g2d.setComposite(AlphaComposite.Clear)
+        g2d.fillRect(0, 0, width, height)
+        g2d.setComposite(AlphaComposite.SrcOver)
+
+        val tx = Tx.translate(width / 2.0, height / 2.0)
+
+        // Render the current drawing to the BufferedImage
+        val (txResult, renderable) = rdr.run(tx).value
+        val (reification, a) = renderable.run.value
+
+        Java2d.render(g2d, reification, txResult)
+        g2d.dispose()
+
+        val filtered = transform(image)
+
+        // Create new Reification from the filtered image
+        val newReification: Reification[A] = WriterT
+          .tell[Eval, List[Reified]](
+            List(Reified.bitmap(Tx.identity, filtered))
+          )
+          .map(_ => a)
+
+        val newRenderable: Renderable[Reification, A] =
+          Renderable.apply(_ => Eval.now(newReification))
+
+        // Update bounding box if image size changed
+        val newBB =
+          if filtered.getWidth != width || filtered.getHeight != height then
+            BoundingBox.centered(
+              filtered.getWidth.toDouble,
+              filtered.getHeight.toDouble
+            )
+          else bb
+
+        (newBB, newRenderable)
+      }
+    }
+
+  private def setupGraphics(g2d: Graphics2D): Unit = {
+    g2d.setRenderingHint(
+      RenderingHints.KEY_ANTIALIASING,
+      RenderingHints.VALUE_ANTIALIAS_ON
+    )
+    g2d.setRenderingHint(
+      RenderingHints.KEY_RENDERING,
+      RenderingHints.VALUE_RENDER_QUALITY
+    )
+  }
+
+  private def applyGaussianBlur(
+      image: BufferedImage,
+      stdDev: Double
+  ): BufferedImage = {
+    val radius = Math.ceil(stdDev * 3).toInt
+    val size = 2 * radius + 1
+    val kernel = createGaussianKernel(size, stdDev)
+
+    val awtKernel = new AwtKernel(size, size, kernel)
+    val op = new ConvolveOp(awtKernel, ConvolveOp.EDGE_NO_OP, null)
+    op.filter(image, null)
+  }
+
+  private def createGaussianKernel(size: Int, stdDev: Double): Array[Float] = {
+    val kernel = Array.ofDim[Float](size * size)
+    val mean = size / 2
+    var sum = 0.0
+
+    for {
+      y <- 0 until size
+      x <- 0 until size
+    } {
+      val value = Math.exp(
+        -0.5 * (Math.pow((x - mean) / stdDev, 2.0) +
+          Math.pow((y - mean) / stdDev, 2.0))
+      ) / (2 * Math.PI * stdDev * stdDev)
+      kernel(y * size + x) = value.toFloat
+      sum += value
+    }
+
+    // Normalize
+    kernel.map(v => (v / sum).toFloat)
+  }
+
+  private def applyConvolution(
+      image: BufferedImage,
+      kernel: Kernel,
+      divisor: Option[Double],
+      bias: Double
+  ): BufferedImage = {
+    val kernelArray =
+      IArray.genericWrapArray(kernel.elements.map(_.toFloat)).toArray
+    val actualDivisor = divisor.getOrElse(kernelArray.sum.toDouble)
+
+    val normalizedKernel =
+      if actualDivisor != 1.0 then
+        kernelArray.map(v => (v / actualDivisor).toFloat)
+      else kernelArray
+
+    val awtKernel = new AwtKernel(kernel.width, kernel.height, normalizedKernel)
+    val op = new ConvolveOp(awtKernel, ConvolveOp.EDGE_NO_OP, null)
+
+    var result = op.filter(image, null)
+
+    // Apply bias if needed
+    if bias != 0.0 then {
+      result = applyBias(result, bias)
+    }
+
+    result
+  }
+
+  private def applyBias(image: BufferedImage, bias: Double): BufferedImage = {
+    val biasInt = (bias * 128).toInt
+
+    for {
+      y <- 0 until image.getHeight
+      x <- 0 until image.getWidth
+    } {
+      val pixel = image.getRGB(x, y)
+      val a = (pixel >> 24) & 0xff
+      val r = Math.min(255, Math.max(0, ((pixel >> 16) & 0xff) + biasInt))
+      val g = Math.min(255, Math.max(0, ((pixel >> 8) & 0xff) + biasInt))
+      val b = Math.min(255, Math.max(0, (pixel & 0xff) + biasInt))
+
+      image.setRGB(x, y, (a << 24) | (r << 16) | (g << 8) | b)
+    }
+
+    image
+  }
+
+  private def applyDropShadow(
+      image: BufferedImage,
+      offsetX: Int,
+      offsetY: Int,
+      blur: Double,
+      shadowColor: Color
+  ): BufferedImage = {
+    // Calculate required size including shadow
+    val extraSpace = Math.ceil(blur * 3).toInt
+    val newWidth = image.getWidth + Math.abs(offsetX) + 2 * extraSpace
+    val newHeight = image.getHeight + Math.abs(offsetY) + 2 * extraSpace
+
+    val result =
+      new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB)
+    val g2d = result.createGraphics()
+    setupGraphics(g2d)
+
+    // Extract alpha channel and create shadow
+    val shadow = extractAlphaAsShadow(image, shadowColor)
+
+    // Apply blur to shadow
+    val blurredShadow =
+      if blur > 0 then applyGaussianBlur(shadow, blur) else shadow
+
+    // Draw shadow with offset
+    val shadowX = if offsetX >= 0 then offsetX + extraSpace else extraSpace
+    val shadowY = if offsetY >= 0 then offsetY + extraSpace else extraSpace
+    g2d.drawImage(blurredShadow, shadowX, shadowY, null)
+
+    // Draw original image on top
+    val origX =
+      if offsetX >= 0 then extraSpace else Math.abs(offsetX) + extraSpace
+    val origY =
+      if offsetY >= 0 then extraSpace else Math.abs(offsetY) + extraSpace
+    g2d.drawImage(image, origX, origY, null)
+
+    g2d.dispose()
+    result
+  }
+
+  private def extractAlphaAsShadow(
+      image: BufferedImage,
+      shadowColor: Color
+  ): BufferedImage = {
+    val result = new BufferedImage(
+      image.getWidth,
+      image.getHeight,
+      BufferedImage.TYPE_INT_ARGB
+    )
+
+    val rgb = shadowColor.toRgb
+    val sr = (rgb.r.get * 255).toInt
+    val sg = (rgb.g.get * 255).toInt
+    val sb = (rgb.b.get * 255).toInt
+    val sa = (rgb.a.get * 255).toInt
+
+    for {
+      y <- 0 until image.getHeight
+      x <- 0 until image.getWidth
+    } {
+      val pixel = image.getRGB(x, y)
+      val alpha = (pixel >> 24) & 0xff
+
+      // Create shadow pixel with original alpha modulated by shadow alpha
+      val shadowAlpha = (alpha * sa) / 255
+      val shadowPixel = (shadowAlpha << 24) | (sr << 16) | (sg << 8) | sb
+      result.setRGB(x, y, shadowPixel)
+    }
+
+    result
+  }
+}

--- a/java2d/src/main/scala/doodle/java2d/examples/Filter.scala
+++ b/java2d/src/main/scala/doodle/java2d/examples/Filter.scala
@@ -1,0 +1,94 @@
+package doodle
+package java2d
+package examples
+
+import cats.effect.*
+import cats.effect.unsafe.implicits.global
+
+import doodle.core.*
+import doodle.java2d.*
+import doodle.syntax.all.*
+
+object Filter extends IOApp {
+
+  def examples: Picture[Unit] = {
+    import doodle.java2d.Picture.*
+
+    val baseCircle = circle(100).fillColor(Color.blue)
+    val baseSquare = square(80).fillColor(Color.red)
+
+    val row1 = List(
+      baseCircle.margin(10),
+      baseCircle.blur(5.0).margin(10),
+      baseCircle.boxBlur(3).margin(10)
+    ).allBeside
+
+    val row2 = List(
+      baseSquare.margin(10),
+      baseSquare.detectEdges.margin(10),
+      baseSquare.sharpen(2.0).margin(10)
+    ).allBeside
+
+    val row3 = List(
+      baseCircle.emboss.margin(10),
+      baseSquare
+        .dropShadow(
+          offsetX = 5.0,
+          offsetY = 5.0,
+          blur = 3.0,
+          color = Color.black.alpha(0.5.normalized)
+        )
+        .margin(10)
+    ).allBeside
+
+    List(row1, row2, row3).allBeside
+  }
+
+  def convolutionExamples: Picture[Unit] = {
+    import doodle.java2d.Picture.*
+    import doodle.algebra.Kernel
+
+    val baseImage = circle(60)
+      .fillColor(Color.orange)
+      .beside(
+        square(60).fillColor(Color.purple)
+      )
+
+    // Custom edge detection kernel
+    val customEdgeKernel = Kernel(
+      3,
+      3,
+      IArray(
+        -1, -1, -1, -1, 8, -1, -1, -1, -1
+      ).map(_.toDouble)
+    )
+
+    // Custom blur kernel
+    val customBlurKernel = Kernel(
+      3,
+      3,
+      IArray(
+        1, 2, 1, 2, 4, 2, 1, 2, 1
+      ).map(d => d / 16.0)
+    )
+
+    List(
+      baseImage.margin(50),
+      baseImage.convolve(customEdgeKernel).margin(50),
+      baseImage.convolve(customBlurKernel).margin(50)
+    ).allBeside
+  }
+
+  def run(args: List[String]): IO[ExitCode] = {
+    val frame = Frame.default
+      .withSize(800, 600)
+      .withBackground(Color.lightGray)
+      .withTitle("Java2D Filter Examples")
+
+    val picture = examples.above(convolutionExamples.margin(90))
+
+    IO {
+      picture.drawWithFrame(frame)
+    } *> IO.never.as(ExitCode.Success)
+  }
+}

--- a/java2d/src/main/scala/doodle/java2d/examples/FilterDebug.scala
+++ b/java2d/src/main/scala/doodle/java2d/examples/FilterDebug.scala
@@ -1,0 +1,27 @@
+package doodle
+package java2d
+package examples
+
+import cats.effect.*
+import cats.effect.unsafe.implicits.global
+
+import doodle.core.*
+import doodle.java2d.*
+import doodle.syntax.all.*
+
+object FilterDebug extends IOApp {
+  def run(args: List[String]): IO[ExitCode] = {
+    val original = circle(50).fillColor(Color.red)
+    val blurred = original.blur(3.0)
+
+    val frame = Frame.default
+      .withSize(400, 200)
+      .withTitle("Filter Debug")
+
+    val picture = original.beside(blurred)
+
+    IO {
+      picture.drawWithFrame(frame)
+    } *> IO.never.as(ExitCode.Success)
+  }
+}

--- a/java2d/src/main/scala/doodle/java2d/package.scala
+++ b/java2d/src/main/scala/doodle/java2d/package.scala
@@ -38,6 +38,7 @@ package object java2d extends Java2dToPicture {
     doodle.algebra.Algebra
       with Basic
       with Bitmap
+      with Filter
       with FromBufferedImage
       with FromPngBase64
       with FromGifBase64
@@ -88,6 +89,7 @@ package object java2d extends Java2dToPicture {
   object Picture
       extends BaseConstructor
       with BitmapConstructor
+      with FilterConstructor
       with FromGifBase64Constructor
       with FromPngBase64Constructor
       with FromJpgBase64Constructor

--- a/java2d/src/test/scala/doodle/java2d/Java2dFilterSuite.scala
+++ b/java2d/src/test/scala/doodle/java2d/Java2dFilterSuite.scala
@@ -1,0 +1,171 @@
+package doodle
+package java2d
+
+import doodle.algebra.Kernel
+import doodle.core.*
+import doodle.java2d.*
+import doodle.syntax.all.*
+import munit.FunSuite
+import java.awt.image.BufferedImage
+import cats.effect.unsafe.implicits.global
+
+class Java2dFilterSuite extends FunSuite {
+
+  // Helper to render a picture to BufferedImage using the BufferedImageWriter
+  def renderToImage(picture: Picture[Unit]): BufferedImage = {
+
+    val frame = Frame.default.withSize(100, 100)
+    val (_, image) = picture.bufferedImage(frame)
+    image
+  }
+
+  test("gaussianBlur should actually blur the image") {
+    val sharp = Picture.circle(20).fillColor(Color.red)
+    val blurred = sharp.blur(3.0)
+
+    val sharpImage = renderToImage(sharp)
+    val blurredImage = renderToImage(blurred)
+
+    // Check that edge pixels are different (blur spreads color)
+    val sharpEdgePixel = sharpImage.getRGB(10, 50)
+    val blurredEdgePixel = blurredImage.getRGB(10, 50)
+
+    // Blurred image should have color spreading to previously empty areas
+    assertNotEquals(sharpEdgePixel, blurredEdgePixel)
+
+    // Verify image dimensions are preserved or expanded (for edge handling)
+    assert(blurredImage.getWidth >= sharpImage.getWidth)
+    assert(blurredImage.getHeight >= sharpImage.getHeight)
+  }
+
+  test("detectEdges should highlight boundaries") {
+    val solid = Picture.square(40).fillColor(Color.blue)
+    val edges = solid.detectEdges
+
+    val solidImage = renderToImage(solid)
+    val edgeImage = renderToImage(edges)
+
+    // Center of solid square should be different after edge detection
+    val centerX = solidImage.getWidth / 2
+    val centerY = solidImage.getHeight / 2
+
+    val originalCenter = solidImage.getRGB(centerX, centerY)
+    val edgeCenter = edgeImage.getRGB(centerX, centerY)
+
+    // Edge detection should change the center pixels
+    assertNotEquals(originalCenter, edgeCenter)
+  }
+
+  test("boxBlur kernel should have correct properties") {
+    val radius = 2
+    val size = 2 * radius + 1
+    val expectedKernelSize = size * size
+
+    val kernel = Kernel(
+      size,
+      size,
+      IArray.fill(expectedKernelSize)(1.0 / expectedKernelSize)
+    )
+
+    assertEquals(kernel.width, 5)
+    assertEquals(kernel.height, 5)
+    assertEquals(kernel.elements.length, 25)
+
+    val expectedValue = 1.0 / 25.0
+    kernel.elements.foreach { value =>
+      assertEquals(value, expectedValue, 0.0001)
+    }
+
+    // Kernel should sum to 1 (for proper normalization)
+    val sum = kernel.elements.foldLeft(0.0)(_ + _)
+    assertEquals(sum, 1.0, 0.001)
+  }
+
+  test("sharpen kernel should emphasize center") {
+    val kernel = doodle.algebra.Filter.sharpenKernel
+
+    // Center element should be positive and larger than 1
+    val centerIndex = (kernel.height / 2) * kernel.width + (kernel.width / 2)
+    assert(kernel.elements(centerIndex) > 1.0)
+
+    // Adjacent elements should be negative (for contrast)
+    assert(kernel.elements(1) < 0) // top
+    assert(kernel.elements(3) < 0) // left
+    assert(kernel.elements(5) < 0) // right
+    assert(kernel.elements(7) < 0) // bottom
+  }
+
+  test("emboss kernel should be asymmetric") {
+    val kernel = doodle.algebra.Filter.embossKernel
+
+    // Emboss kernels are typically asymmetric to create 3D effect
+    val topLeft = kernel.elements(0)
+    val bottomRight = kernel.elements(kernel.elements.length - 1)
+
+    // These should have opposite signs for emboss effect
+    assert(topLeft * bottomRight < 0)
+  }
+
+  test("dropShadow should create offset shadow") {
+    val circle = Picture.circle(20).fillColor(Color.red)
+    val withShadow = circle.dropShadow(10, 10, 0, Color.black)
+
+    val originalImage = renderToImage(circle)
+    val shadowImage = renderToImage(withShadow)
+
+    assert(shadowImage.getWidth >= originalImage.getWidth)
+    assert(shadowImage.getHeight >= originalImage.getHeight)
+
+    val shadowX = 10
+    val shadowY = 10
+    val shadowPixel = shadowImage.getRGB(shadowX, shadowY)
+    val shadowAlpha = (shadowPixel >> 24) & 0xff
+
+    assert(shadowAlpha > 0)
+  }
+
+  test("convolve with identity kernel should preserve image") {
+    val identityKernel = Kernel(
+      3,
+      3,
+      IArray(
+        0, 0, 0, 0, 1, 0, 0, 0, 0
+      ).map(_.toDouble)
+    )
+
+    val original = Picture.square(30).fillColor(Color.green)
+    val convolved = original.convolve(identityKernel)
+
+    val originalImage = renderToImage(original)
+    val convolvedImage = renderToImage(convolved)
+
+    val centerX = originalImage.getWidth / 2
+    val centerY = originalImage.getHeight / 2
+
+    val origPixel = originalImage.getRGB(centerX, centerY)
+    val convPixel = convolvedImage.getRGB(centerX, centerY)
+
+    // Center pixels should be very similar
+    val origR = (origPixel >> 16) & 0xff
+    val convR = (convPixel >> 16) & 0xff
+
+    // Allow small difference due to rounding
+    assert(Math.abs(origR - convR) < 5)
+  }
+
+  test("filter composition should apply in sequence") {
+    val base = Picture.circle(40).fillColor(Color.blue)
+
+    val filtered1 = base.blur(2.0).sharpen(1.5)
+    val filtered2 = base.sharpen(1.5).blur(2.0)
+
+    val image1 = renderToImage(filtered1)
+    val image2 = renderToImage(filtered2)
+
+    val pixel1 = image1.getRGB(50, 50)
+    val pixel2 = image2.getRGB(50, 50)
+
+    // These should be different (non-commutative operations)
+    assertNotEquals(pixel1, pixel2)
+  }
+}


### PR DESCRIPTION
Implements bitmap-based image filtering for Java2d backend using BufferedImage and ConvolveOp.

Adds support for:
- Gaussian blur with configurable standard deviation.
- Box blur with radius parameter.
- Edge detection using convolution kernels.
- Sharpen filter with adjustable intensity.
- Emboss effect.
- Drop shadow simple version.
- Custom convolution matrix operations.

## TODO `dropShadow`
Java2d drop shadow is complex and requires multiple  In this PR is a simplified implementation - full implementation would need:
1. Extract alpha channel as shadow.
2. Apply blur to shadow.
3. Offset shadow.
4. Colorize shadow.
5. Composite original over shadow.

For now, we'll implement a basic version